### PR TITLE
Improve LAN access and dashboard guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+data/
+config/app-config.json
+npm-debug.log
+.DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,85 @@
-# monkey-tracker
-monkey tracker webgui
+# Drone Tracker Web Application
+
+This project exposes the **Drone Tracker** interface as a full web application built with Express.js and a modular data layer. The UI is re-engineered from the original `Drone_Tracker_v0.8.5.html` file and now persists show data using either a local SQL database (SQLite) or a remote Coda table.
+
+## Features
+
+- Full-featured front-end built with HTML and CSS that retains the original look-and-feel and now surfaces a LAN connection dashboard for quick status checks.
+- Express.js backend API that manages shows, entries, and configuration.
+- Modular storage providers:
+  - **SQL (SQLite)** – default provider. The server creates the database file if it does not exist.
+  - **Coda** – push and pull show payloads to a Coda table using the Coda REST API.
+- Configurable application settings from the in-app settings panel (unit label, provider selection, connection parameters).
+- CSV and JSON export for the active show.
+- Entry editor modal with validation consistent with the original workflow.
+
+## Getting Started
+
+1. Install dependencies at the repository root:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the server directly with Node (Express binds to `10.241.211.120` by default so the app is reachable across the LAN):
+
+   ```bash
+   node server/index.js
+   ```
+
+   > Avoid using `npm start` – the project is configured to be launched directly via Node without npm-run scripts.
+
+   The app runs on [http://10.241.211.120:3000](http://10.241.211.120:3000) out of the box. Set the `HOST` and `PORT` environment variables before launching if you need a different binding (for example `HOST=0.0.0.0 node server/index.js`).
+
+3. Open the settings panel (gear icon) to choose the storage provider and supply the required connection parameters. By default the app uses SQLite and stores data in `data/monkey-tracker.sqlite`.
+
+## Configuration
+
+The runtime configuration is stored in `config/app-config.json` (created automatically on first run). A template is provided at `config/app-config.example.json` for reference. When settings are saved through the UI the server reloads the storage provider with the new configuration.
+
+### Server binding
+
+- **host** – interface/IP address the Express server should listen on. Defaults to `10.241.211.120` so the dashboard is reachable across the LAN.
+- **port** – TCP port used by the server. Defaults to `3000`.
+
+> Update these values in `config/app-config.json` (or via environment variables) and restart `node server/index.js` for changes to take effect.
+
+### SQL Provider
+
+- **filename** – path to the SQLite database file. The directory is created if it does not exist. Shows are stored as JSON documents inside the `shows` table.
+
+### Coda Provider
+
+Provide the following values in the settings panel:
+
+- **API token** – personal API token from Coda.
+- **Doc ID** – the identifier of the Coda doc (e.g. `doc_XXXX`).
+- **Table ID** – the target table ID (e.g. `table_YYYY`).
+- **Show ID column name** – text column that stores the unique show ID.
+- **Payload column name** – text column that stores the JSON payload returned by the app.
+
+> **Note:** The Coda provider requires a table with text columns capable of storing the show ID and JSON payload. The provider fetches and replaces complete show documents, including their entries.
+
+## API Overview
+
+The Express backend exposes the following endpoints (all JSON):
+
+- `GET /api/config` / `PUT /api/config` – read or update application configuration.
+- `GET /api/shows` – list shows for the active provider.
+- `POST /api/shows` – create a new show.
+- `GET /api/shows/:id` – retrieve a single show.
+- `PUT /api/shows/:id` – update show metadata.
+- `DELETE /api/shows/:id` – remove a show.
+- `POST /api/shows/:id/entries` – add an entry to a show.
+- `PUT /api/shows/:id/entries/:entryId` – update an entry.
+- `DELETE /api/shows/:id/entries/:entryId` – delete an entry.
+
+## Development Notes
+
+- The project uses ES modules in the front-end (`public/app.js`) and CommonJS on the server.
+- Static assets are served from the `public/` directory.
+- `config/app-config.json` and `data/` are ignored by Git so that environment-specific configuration and data files stay local.
+
+## Original Asset
+
+The original standalone HTML file is kept at `Drone_Tracker_v0.8.5.html` for reference.

--- a/config/app-config.example.json
+++ b/config/app-config.example.json
@@ -1,0 +1,16 @@
+{
+  "host": "10.241.211.120",
+  "port": 3000,
+  "unitLabel": "Drone",
+  "provider": "sql",
+  "sql": {
+    "filename": "data/monkey-tracker.sqlite"
+  },
+  "coda": {
+    "apiToken": "YOUR_CODA_TOKEN",
+    "docId": "doc_xxx",
+    "tableId": "table_xxx",
+    "showIdColumn": "Show ID",
+    "payloadColumn": "Payload"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2419 @@
+{
+  "name": "monkey-tracker",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "monkey-tracker",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "axios": "^1.12.2",
+        "express": "^5.1.0",
+        "morgan": "^1.10.1",
+        "sqlite": "^5.1.1",
+        "sqlite3": "^5.1.7",
+        "uuid": "^13.0.0"
+      }
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/morgan": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/morgan/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/sqlite": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/sqlite/-/sqlite-5.1.1.tgz",
+      "integrity": "sha512-oBkezXa2hnkfuJwUo44Hl9hS3er+YFtueifoajrgidvqsJRQFpc5fKoAkAor1O5ZnLoa28GBScfHXs8j0K358Q==",
+      "license": "MIT"
+    },
+    "node_modules/sqlite3": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1",
+        "tar": "^6.1.11"
+      },
+      "optionalDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependenciesMeta": {
+        "node-gyp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "monkey-tracker",
+  "version": "1.0.0",
+  "description": "monkey tracker webgui",
+  "main": "server/index.js",
+  "scripts": {
+    "test": "echo \"No automated tests configured\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "axios": "^1.12.2",
+    "express": "^5.1.0",
+    "morgan": "^1.10.1",
+    "sqlite": "^5.1.1",
+    "sqlite3": "^5.1.7",
+    "uuid": "^13.0.0"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,1180 @@
+const ISSUE_MAP = {
+  'Tracking lost': ['occlusion','calibration','marker loss','software','unknown'],
+  'Failed to launch': ['mechanical','arming','safety','unknown'],
+  'Command delay': ['network latency','controller queue','unknown'],
+  'RF link': ['TX fault','RX fault','interference','antenna','unknown'],
+  'Battery': ['low voltage','BMS fault','poor contact','swelling','unknown'],
+  'Motor or prop': ['no spin','desync','damage','unknown'],
+  'Sensor or IMU': ['bias','calibration','saturation','unknown'],
+  'Software or show control': ['cue timing','state desync','crash','unknown'],
+  'Pilot input': ['incorrect mode','early abort','missed cue','unknown'],
+  Other: []
+};
+const PRIMARY_ISSUES = Object.keys(ISSUE_MAP);
+const ACTIONS = ['Reboot','Swap battery','Swap drone','Retry launch','Abort segment','Logged only'];
+const DEFAULT_CREW = ['Alex','Nick','John Henery','James','Robert','Nazar'];
+const STATUS = ['Completed','No-launch','Abort'];
+
+const state = {
+  config: null,
+  unitLabel: 'Drone',
+  shows: [],
+  currentShowId: null,
+  editingEntryRef: null,
+  serverHost: '10.241.211.120',
+  serverPort: 3000,
+  activeProvider: null
+};
+
+const appTitle = el('appTitle');
+const unitLabelEl = el('unitLabel');
+const showDate = el('showDate');
+const showTime = el('showTime');
+const showLabel = el('showLabel');
+const showNotes = el('showNotes');
+const crewInput = el('crewInput');
+const leadPilotSelect = el('leadPilot');
+const monkeyLeadSelect = el('monkeyLead');
+const unitId = el('unitId');
+const planned = el('planned');
+const launched = el('launched');
+const stCompleted = el('stCompleted');
+const stNoLaunch = el('stNoLaunch');
+const stAbort = el('stAbort');
+const primaryIssue = el('primaryIssue');
+const subIssue = el('subIssue');
+const otherDetail = el('otherDetail');
+const otherDetailWrap = el('otherDetailWrap');
+const severity = el('severity');
+const rootCause = el('rootCause');
+const actionsChips = el('actionsChips');
+const operator = el('operator');
+const batteryId = el('batteryId');
+const delaySec = el('delaySec');
+const commandRx = el('commandRx');
+const entryNotes = el('entryNotes');
+const groupsContainer = el('groups');
+const issueBlocks = qsa('.issue-block');
+const toastEl = el('toast');
+const editModal = el('editModal');
+const editForm = el('editForm');
+const configBtn = el('configBtn');
+const configPanel = el('configPanel');
+const closeConfigBtn = el('closeConfig');
+const cancelConfigBtn = el('cancelConfig');
+const configForm = el('configForm');
+const configMessage = el('configMessage');
+const providerSelect = el('providerSelect');
+const unitLabelSelect = el('unitLabelSelect');
+const sqlFields = el('sqlFields');
+const codaFields = el('codaFields');
+const sqlFilename = el('sqlFilename');
+const codaToken = el('codaToken');
+const codaDoc = el('codaDoc');
+const codaTable = el('codaTable');
+const codaShowId = el('codaShowId');
+const codaPayload = el('codaPayload');
+const connectionStatusEl = el('connectionStatus');
+const providerBadge = el('providerBadge');
+const refreshShowsBtn = el('refreshShows');
+const lanAddressEl = el('lanAddress');
+
+init().catch(err=>{
+  console.error(err);
+  toast('Failed to initialise application', true);
+});
+
+async function init(){
+  await loadConfig();
+  updateConnectionIndicator('loading');
+  await loadShows();
+  initUI();
+  fillHeader(getCurrentShow());
+  renderGroups();
+  updateIssueVisibility();
+  populateUnitOptions();
+  populateIssues();
+  renderActionsChips(actionsChips, []);
+  renderOperatorOptions();
+  adjustContainerBottomPadding();
+}
+
+function initUI(){
+  [stCompleted, stNoLaunch, stAbort].forEach(btn=>{
+    btn.addEventListener('click', ()=>{
+      setStatus(btn.dataset.status);
+      updateIssueVisibility();
+    });
+  });
+  planned.addEventListener('change', onPlanLaunchChange);
+  launched.addEventListener('change', onPlanLaunchChange);
+  primaryIssue.addEventListener('change', ()=>{
+    populateSubIssues(primaryIssue.value);
+    updateIssueVisibility();
+  });
+
+  showDate.addEventListener('change', ()=> updateShowField('date', showDate.value));
+  showTime.addEventListener('change', ()=> updateShowField('time', showTime.value));
+  showLabel.addEventListener('input', debounce(()=> updateShowField('label', showLabel.value.trim()), 400));
+  showNotes.addEventListener('input', debounce(()=> updateShowField('notes', showNotes.value.trim()), 400));
+  leadPilotSelect.addEventListener('change', ()=> updateShowField('leadPilot', leadPilotSelect.value));
+  monkeyLeadSelect.addEventListener('change', ()=> updateShowField('monkeyLead', monkeyLeadSelect.value));
+
+  el('newShow').addEventListener('click', onNewShow);
+  el('dupShow').addEventListener('click', onDuplicateShow);
+  el('addLine').addEventListener('click', onAddLine);
+  el('exportCsv').addEventListener('click', onExportCsv);
+  el('exportJson').addEventListener('click', onExportJson);
+
+  el('closeEdit').addEventListener('click', closeEditModal);
+  el('saveEdit').addEventListener('click', saveEditEntry);
+
+  configBtn.addEventListener('click', ()=> toggleConfig(true));
+  closeConfigBtn.addEventListener('click', ()=> toggleConfig(false));
+  cancelConfigBtn.addEventListener('click', ()=> toggleConfig(false));
+  document.addEventListener('keydown', e=>{
+    if(e.key === 'Escape'){
+      toggleConfig(false);
+      closeEditModal();
+    }
+  });
+
+  configForm.addEventListener('submit', onConfigSubmit);
+  providerSelect.addEventListener('change', onProviderChange);
+  if(refreshShowsBtn){
+    refreshShowsBtn.dataset.label = refreshShowsBtn.textContent;
+    refreshShowsBtn.addEventListener('click', onRefreshShows);
+  }
+
+  window.addEventListener('resize', adjustContainerBottomPadding);
+  if('ResizeObserver' in window){
+    const ro = new ResizeObserver(adjustContainerBottomPadding);
+    const footer = document.querySelector('.sticky-footer');
+    if(footer){
+      ro.observe(footer);
+    }
+  }
+}
+
+async function loadConfig(){
+  const data = await apiRequest('/api/config');
+  state.config = data;
+  state.serverHost = data.host || state.serverHost;
+  const portFromConfig = Number.parseInt(data.port, 10);
+  state.serverPort = Number.isFinite(portFromConfig) ? portFromConfig : state.serverPort;
+  state.unitLabel = data.unitLabel || 'Drone';
+  state.activeProvider = data.provider || state.activeProvider || 'sql';
+  appTitle.textContent = state.unitLabel;
+  unitLabelEl.textContent = state.unitLabel;
+  providerSelect.value = data.provider || 'sql';
+  unitLabelSelect.value = state.unitLabel;
+  sqlFilename.value = data.sql?.filename || '';
+  codaToken.value = data.coda?.apiToken || '';
+  codaDoc.value = data.coda?.docId || '';
+  codaTable.value = data.coda?.tableId || '';
+  codaShowId.value = data.coda?.showIdColumn || '';
+  codaPayload.value = data.coda?.payloadColumn || '';
+  setLanAddress();
+  setProviderBadge(state.activeProvider);
+  onProviderChange();
+}
+
+async function loadShows(){
+  try{
+    const data = await apiRequest('/api/shows');
+    state.activeProvider = data.provider || state.config?.provider || state.activeProvider || 'sql';
+    state.shows = Array.isArray(data.shows) ? data.shows : [];
+    sortShows();
+    state.currentShowId = state.shows[0]?.id || null;
+    updateConnectionIndicator();
+  }catch(err){
+    console.error('Failed to load shows', err);
+    state.shows = [];
+    state.currentShowId = null;
+    toast('Failed to load shows', true);
+    updateConnectionIndicator('error');
+  }
+}
+
+async function onRefreshShows(){
+  let originalLabel = '';
+  if(refreshShowsBtn){
+    originalLabel = refreshShowsBtn.dataset.label || refreshShowsBtn.textContent;
+    refreshShowsBtn.disabled = true;
+    refreshShowsBtn.textContent = 'Refreshing…';
+  }
+  updateConnectionIndicator('loading');
+  try{
+    await loadShows();
+    fillHeader(getCurrentShow());
+    renderGroups();
+    updateIssueVisibility();
+    renderOperatorOptions();
+    toast('Data refreshed');
+  }catch(err){
+    console.error('Failed to refresh shows', err);
+    toast('Failed to refresh data', true);
+  }finally{
+    if(refreshShowsBtn){
+      refreshShowsBtn.disabled = false;
+      refreshShowsBtn.textContent = originalLabel || 'Refresh data';
+    }
+  }
+}
+
+function getCurrentShow(){
+  if(!state.currentShowId){
+    return null;
+  }
+  return state.shows.find(s=>s.id===state.currentShowId) || null;
+}
+
+function upsertShow(show){
+  const idx = state.shows.findIndex(s=>s.id===show.id);
+  if(idx >= 0){
+    state.shows[idx] = show;
+  }else{
+    state.shows.unshift(show);
+  }
+  sortShows();
+}
+
+function sortShows(){
+  state.shows.sort((a,b)=>{
+    const au = a.updatedAt || a.createdAt || 0;
+    const bu = b.updatedAt || b.createdAt || 0;
+    return bu - au;
+  });
+}
+
+function fillHeader(show){
+  if(!show){
+    showDate.value = '';
+    showTime.value = '';
+    showLabel.value = '';
+    showNotes.value = '';
+    initCrewChipInput(crewInput, [], ()=>{});
+    leadPilotSelect.innerHTML = '<option value="">Select</option>';
+    monkeyLeadSelect.innerHTML = '<option value="">Select</option>';
+    return;
+  }
+  showDate.value = show.date || '';
+  showTime.value = show.time || '';
+  showLabel.value = show.label || '';
+  showNotes.value = show.notes || '';
+  initCrewChipInput(crewInput, show.crew || [], names=>{
+    updateShowField('crew', names);
+    renderOperatorOptions();
+  });
+  renderOperatorOptions();
+  const crewOptions = [''].concat(show.crew || [], DEFAULT_CREW);
+  const uniqueOptions = [...new Set(crewOptions.filter(Boolean))];
+  leadPilotSelect.innerHTML = '<option value="">Select</option>' + uniqueOptions.map(name=>`<option ${show.leadPilot===name?'selected':''}>${escapeHtml(name)}</option>`).join('');
+  monkeyLeadSelect.innerHTML = '<option value="">Select</option>' + uniqueOptions.map(name=>`<option ${show.monkeyLead===name?'selected':''}>${escapeHtml(name)}</option>`).join('');
+}
+
+function populateUnitOptions(){
+  const units = getDefaultUnits();
+  const currentValue = unitId.value;
+  unitId.innerHTML = '<option value="">Select</option>' + units.map(u=>`<option ${currentValue===u?'selected':''}>${u}</option>`).join('');
+  unitLabelEl.textContent = state.unitLabel;
+  appTitle.textContent = state.unitLabel;
+}
+
+function populateIssues(){
+  primaryIssue.innerHTML = '<option value="">Select</option>' + PRIMARY_ISSUES.map(issue=>`<option value="${issue}">${issue}</option>`).join('');
+  populateSubIssues(primaryIssue.value);
+}
+
+function populateSubIssues(primary){
+  const options = ISSUE_MAP[primary] || [];
+  subIssue.innerHTML = '<option value="">N/A</option>' + options.map(opt=>`<option value="${opt}">${opt}</option>`).join('');
+}
+
+function renderActionsChips(container, selected){
+  container.innerHTML = '';
+  ACTIONS.forEach(action=>{
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = 'action-chip';
+    chip.textContent = action;
+    const isSelected = selected.includes(action);
+    chip.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+    chip.addEventListener('click', ()=>{
+      const pressed = chip.getAttribute('aria-pressed') === 'true';
+      chip.setAttribute('aria-pressed', pressed ? 'false' : 'true');
+    });
+    container.appendChild(chip);
+  });
+}
+
+function getSelectedActions(container){
+  return qsa('.action-chip', container).filter(chip=>chip.getAttribute('aria-pressed') === 'true').map(chip=>chip.textContent);
+}
+
+function updateIssueVisibility(){
+  const st = getStatus();
+  const showIssues = st && st !== 'Completed';
+  issueBlocks.forEach(block=> block.classList.toggle('hidden', !showIssues));
+  const isOther = primaryIssue.value === 'Other';
+  otherDetailWrap.classList.toggle('hidden', !showIssues || !isOther);
+}
+
+function getStatus(){
+  const selected = [stCompleted, stNoLaunch, stAbort].find(btn=>btn.getAttribute('aria-pressed') === 'true');
+  return selected ? selected.dataset.status : '';
+}
+
+function setStatus(status){
+  [stCompleted, stNoLaunch, stAbort].forEach(btn=>{
+    btn.setAttribute('aria-pressed', btn.dataset.status === status ? 'true' : 'false');
+  });
+}
+
+function onPlanLaunchChange(){
+  const st = getStatus();
+  if(planned.value === 'No' && st && st !== 'No-launch'){
+    setStatus('No-launch');
+  }
+  if(launched.value === 'No' && st && st !== 'No-launch'){
+    setStatus('No-launch');
+  }
+  if(launched.value === 'Yes' && st === 'No-launch'){
+    setStatus('Completed');
+  }
+  updateIssueVisibility();
+}
+
+async function onNewShow(){
+  try{
+    const payload = await apiRequest('/api/shows', {method:'POST', body: JSON.stringify({})});
+    upsertShow(payload);
+    state.currentShowId = payload.id;
+    fillHeader(payload);
+    clearEntryForm();
+    renderGroups();
+    toast('New show created');
+  }catch(err){
+    console.error(err);
+    toast('Failed to create show', true);
+  }
+}
+
+async function onDuplicateShow(){
+  const current = getCurrentShow();
+  if(!current){
+    await onNewShow();
+    return;
+  }
+  try{
+    const dupPayload = {
+      date: current.date,
+      time: current.time,
+      label: current.label,
+      crew: [...(current.crew||[])],
+      leadPilot: current.leadPilot || '',
+      monkeyLead: current.monkeyLead || '',
+      notes: current.notes || ''
+    };
+    const payload = await apiRequest('/api/shows', {method:'POST', body: JSON.stringify(dupPayload)});
+    upsertShow(payload);
+    state.currentShowId = payload.id;
+    fillHeader(payload);
+    clearEntryForm();
+    renderGroups();
+    toast('Show duplicated');
+  }catch(err){
+    console.error(err);
+    toast('Failed to duplicate show', true);
+  }
+}
+
+async function updateShowField(field, value){
+  const show = getCurrentShow();
+  if(!show){
+    return;
+  }
+  try{
+    const updated = await apiRequest(`/api/shows/${show.id}`, {method:'PUT', body: JSON.stringify({[field]: value})});
+    upsertShow(updated);
+    state.currentShowId = updated.id;
+    if(field === 'crew'){
+      renderOperatorOptions();
+    }
+    renderGroups();
+  }catch(err){
+    console.error(err);
+    toast('Failed to update show', true);
+  }
+}
+
+async function onAddLine(){
+  const show = getCurrentShow();
+  if(!show){
+    toast('Create a show first', true);
+    return;
+  }
+  clearErrors();
+  let ok = true;
+  if(!showDate.value){ showError('errDate'); ok=false; }
+  if(!showTime.value){ showError('errTime'); ok=false; }
+  if(!unitId.value){ showError('errUnit'); ok=false; }
+  if(!planned.value){ showError('errPlanned'); ok=false; }
+  if(!launched.value){ showError('errLaunched'); ok=false; }
+  const st = getStatus();
+  if(!st){ showError('errStatus'); ok=false; }
+  if(planned.value === 'No' && st !== 'No-launch'){ showError('errStatus'); toast('If Planned is No, Status must be No-launch', true); ok=false; }
+  if(launched.value === 'No' && st !== 'No-launch'){ showError('errStatus'); toast('If Launched is No, Status must be No-launch', true); ok=false; }
+  if(launched.value === 'Yes' && st === 'No-launch'){ showError('errStatus'); toast('If Launched is Yes, Status cannot be No-launch', true); ok=false; }
+  if(st !== 'Completed'){
+    if(!primaryIssue.value){ showError('errPrimary'); ok=false; }
+    if(!severity.value){ showError('errSeverity'); ok=false; }
+    if(primaryIssue.value === 'Other' && !otherDetail.value.trim()){ showError('errOther'); ok=false; }
+  }
+  if(delaySec.value){
+    const v = Number(delaySec.value);
+    if(!Number.isFinite(v) || v < 0){ showError('errDelay'); ok=false; }
+  }
+  if(!ok){ return; }
+
+  const entry = {
+    unitId: unitId.value,
+    planned: planned.value,
+    launched: launched.value,
+    status: st,
+    primaryIssue: st === 'Completed' ? '' : primaryIssue.value,
+    subIssue: st === 'Completed' ? '' : (subIssue.value || ''),
+    otherDetail: st === 'Completed' ? '' : (primaryIssue.value === 'Other' ? otherDetail.value.trim() : ''),
+    severity: st === 'Completed' ? '' : (severity.value || ''),
+    rootCause: st === 'Completed' ? '' : (rootCause.value || ''),
+    actions: st === 'Completed' ? [] : getSelectedActions(actionsChips),
+    operator: operator.value || '',
+    batteryId: batteryId.value.trim(),
+    delaySec: delaySec.value ? Number(delaySec.value) : null,
+    commandRx: commandRx.value || '',
+    notes: entryNotes.value.trim()
+  };
+
+  try{
+    await apiRequest(`/api/shows/${show.id}/entries`, {method:'POST', body: JSON.stringify(entry)});
+    const updatedShow = await apiRequest(`/api/shows/${show.id}`, {method:'GET'});
+    upsertShow(updatedShow);
+    state.currentShowId = updatedShow.id;
+    clearEntryForm();
+    renderGroups();
+    toast('Line added');
+  }catch(err){
+    console.error(err);
+    toast('Failed to add entry', true);
+  }
+}
+
+function clearEntryForm(){
+  unitId.value = '';
+  planned.value = '';
+  launched.value = '';
+  setStatus('');
+  primaryIssue.value = '';
+  subIssue.innerHTML = '<option value="">N/A</option>';
+  otherDetail.value = '';
+  severity.value = '';
+  rootCause.value = '';
+  renderActionsChips(actionsChips, []);
+  operator.value = '';
+  batteryId.value = '';
+  delaySec.value = '';
+  commandRx.value = '';
+  entryNotes.value = '';
+  updateIssueVisibility();
+}
+
+function renderGroups(){
+  sortShows();
+  groupsContainer.innerHTML = '';
+  state.shows.forEach(show=>{
+    const isOpen = show.id === state.currentShowId;
+    const group = document.createElement('details');
+    group.className = 'group';
+    group.open = isOpen;
+    const summary = document.createElement('summary');
+    summary.innerHTML = `<div class="group-title">${groupTitle(show)}</div><div class="badge">${show.entries?.length || 0} entries</div>`;
+    summary.addEventListener('click', ()=>{
+      setTimeout(()=>{
+        if(group.open){
+          state.currentShowId = show.id;
+          fillHeader(show);
+          renderOperatorOptions();
+        }
+      }, 0);
+    });
+    const metricsDiv = document.createElement('div');
+    const metrics = computeMetrics(show);
+    metricsDiv.className = 'metrics';
+    metricsDiv.innerHTML = `
+      <div class="metric">Launch success: <b>${metrics.successRate}%</b></div>
+      <div class="metric">Completed: <b>${metrics.countCompleted}</b></div>
+      <div class="metric">No-launch: <b>${metrics.countNoLaunch}</b></div>
+      <div class="metric">Abort: <b>${metrics.countAbort}</b></div>
+      <div class="metric">Avg delay: <b>${metrics.avgDelay}</b> s</div>
+      <div class="metric">Top issues: <b>${metrics.topIssues.join(', ') || 'n/a'}</b></div>
+    `;
+    const rows = document.createElement('div');
+    rows.className = 'rows';
+    const header = document.createElement('div');
+    header.className = 'rowcard';
+    header.style.background = '#1a1d26';
+    header.style.fontWeight = '700';
+    header.style.color = 'var(--text-dim)';
+    header.style.borderBottom = '2px solid var(--border)';
+    const idHeader = state.unitLabel === 'Monkey' ? 'M#' : 'D#';
+    header.innerHTML = `
+      <div><b>${idHeader}</b></div>
+      <div><b>Planned</b></div>
+      <div><b>Launched</b></div>
+      <div><b>Status</b></div>
+      <div><b>Issue</b></div>
+      <div><b>Operator</b></div>
+      <div><b>Notes</b></div>
+      <div></div>
+    `;
+    rows.appendChild(header);
+    (show.entries || []).slice().sort((a,b)=> (b.ts||0) - (a.ts||0)).forEach(entry=>{
+      rows.appendChild(renderRow(show, entry));
+    });
+    group.appendChild(summary);
+    group.appendChild(metricsDiv);
+    group.appendChild(rows);
+    groupsContainer.appendChild(group);
+  });
+}
+
+function groupTitle(show){
+  const d = formatDateUS(show.date) || 'MM-DD-YYYY';
+  const t = formatTime12Hour(show.time) || 'HH:mm';
+  const label = show.label ? ` • ${escapeHtml(show.label)}` : '';
+  return `${d} • ${t}${label}`;
+}
+
+function renderRow(show, entry){
+  const row = document.createElement('div');
+  row.className = 'rowcard';
+  const colorDot = entry.status === 'Completed' ? 'dot-success' : entry.status === 'Abort' ? 'dot-warn' : 'dot-danger';
+  const issueTxt = entry.status === 'Completed' ? '' : [entry.primaryIssue, entry.subIssue || entry.otherDetail].filter(Boolean).join(' / ');
+  row.innerHTML = `
+    <div><b>${escapeHtml(entry.unitId || '')}</b></div>
+    <div>${escapeHtml(entry.planned || '')}</div>
+    <div>${escapeHtml(entry.launched || '')}</div>
+    <div><span class="status-dot ${colorDot}"></span>${escapeHtml(entry.status || '')}</div>
+    <div>${escapeHtml(issueTxt)}</div>
+    <div>${escapeHtml(entry.operator || '')}</div>
+    <div>${escapeHtml(entry.notes || '')}</div>
+    <div class="menu" data-menu>
+      <button class="menu-btn" title="Row menu" aria-haspopup="true" aria-expanded="false">⋯</button>
+      <div class="menu-list" role="menu">
+        <button class="menu-item" role="menuitem" data-edit>Edit</button>
+        <button class="menu-item" role="menuitem" data-delete>Delete</button>
+      </div>
+    </div>
+  `;
+  const menu = qs('[data-menu]', row);
+  const btn = qs('.menu-btn', menu);
+  btn.addEventListener('click', e=>{
+    e.stopPropagation();
+    const open = menu.hasAttribute('open');
+    closeAllMenus();
+    if(!open){
+      menu.setAttribute('open', '');
+    }
+    btn.setAttribute('aria-expanded', String(!open));
+    document.addEventListener('click', closeAllMenus, {once:true});
+  });
+  qs('[data-edit]', row).addEventListener('click', ()=>{
+    menu.removeAttribute('open');
+    openEditModal(show.id, entry.id);
+  });
+  qs('[data-delete]', row).addEventListener('click', async ()=>{
+    menu.removeAttribute('open');
+    if(confirm('Delete this entry?')){
+      await deleteEntry(show.id, entry.id);
+    }
+  });
+  return row;
+}
+
+async function deleteEntry(showId, entryId){
+  try{
+    await apiRequest(`/api/shows/${showId}/entries/${entryId}`, {method:'DELETE'});
+    const updatedShow = await apiRequest(`/api/shows/${showId}`, {method:'GET'});
+    upsertShow(updatedShow);
+    renderGroups();
+    toast('Entry deleted');
+  }catch(err){
+    console.error(err);
+    toast('Failed to delete entry', true);
+  }
+}
+
+function closeAllMenus(){
+  qsa('[data-menu]').forEach(m=>m.removeAttribute('open'));
+}
+
+function computeMetrics(show){
+  const plannedYes = (show.entries||[]).filter(e=>e.planned==='Yes').length;
+  const completed = (show.entries||[]).filter(e=>e.status==='Completed').length;
+  const noLaunch = (show.entries||[]).filter(e=>e.status==='No-launch').length;
+  const abort = (show.entries||[]).filter(e=>e.status==='Abort').length;
+  const delays = (show.entries||[]).map(e=>e.delaySec).filter(v=>typeof v === 'number');
+  const avgDelay = delays.length ? (delays.reduce((a,b)=>a+b,0)/delays.length).toFixed(2) : '0.00';
+  const issues = {};
+  (show.entries||[]).forEach(e=>{
+    if(e.status !== 'Completed' && e.primaryIssue){
+      issues[e.primaryIssue] = (issues[e.primaryIssue] || 0) + 1;
+    }
+  });
+  const topIssues = Object.entries(issues).sort((a,b)=>b[1]-a[1]).slice(0,3).map(([key])=>key);
+  const successRate = plannedYes ? Math.round((completed/plannedYes)*100) : 0;
+  return {
+    successRate,
+    countCompleted: completed,
+    countNoLaunch: noLaunch,
+    countAbort: abort,
+    avgDelay,
+    topIssues
+  };
+}
+
+function openEditModal(showId, entryId){
+  const show = state.shows.find(s=>s.id===showId);
+  const entry = show?.entries.find(e=>e.id===entryId);
+  if(!entry){
+    return;
+  }
+  state.editingEntryRef = {showId, entryId};
+  editForm.innerHTML = '';
+  const fields = buildEntryFieldsClone(entry, show);
+  fields.forEach(f=> editForm.appendChild(f));
+  editModal.classList.add('open');
+}
+
+function closeEditModal(){
+  editModal.classList.remove('open');
+  state.editingEntryRef = null;
+}
+
+async function saveEditEntry(){
+  if(!state.editingEntryRef){
+    return;
+  }
+  const show = state.shows.find(s=>s.id===state.editingEntryRef.showId);
+  if(!show){
+    toast('Show not found', true);
+    return;
+  }
+  const form = editForm;
+  const get = id => qs(`#${id}`, form);
+  const status = pillGet(form);
+  if(!get('edit_unitId').value || !get('edit_planned').value || !get('edit_launched').value || !status){
+    toast('Missing required fields', true);
+    return;
+  }
+  if(get('edit_planned').value === 'No' && status !== 'No-launch'){ toast('If Planned is No, Status must be No-launch', true); return; }
+  if(get('edit_launched').value === 'No' && status !== 'No-launch'){ toast('If Launched is No, Status must be No-launch', true); return; }
+  if(get('edit_launched').value === 'Yes' && status === 'No-launch'){ toast('If Launched is Yes, Status cannot be No-launch', true); return; }
+  const prim = get('edit_primaryIssue').value;
+  const sev = get('edit_severity').value;
+  const other = get('edit_otherDetail').value.trim();
+  if(status !== 'Completed'){
+    if(!prim || !sev){ toast('Issue and Severity required when not Completed', true); return; }
+    if(prim === 'Other' && !other){ toast('Other detail required', true); return; }
+  }
+  const entryUpdate = {
+    unitId: get('edit_unitId').value,
+    planned: get('edit_planned').value,
+    launched: get('edit_launched').value,
+    status,
+    primaryIssue: status === 'Completed' ? '' : prim,
+    subIssue: status === 'Completed' ? '' : (get('edit_subIssue').value || ''),
+    otherDetail: status === 'Completed' ? '' : (prim === 'Other' ? other : ''),
+    severity: status === 'Completed' ? '' : sev,
+    rootCause: status === 'Completed' ? '' : get('edit_rootCause').value,
+    actions: status === 'Completed' ? [] : getSelectedActions(qs('#edit_actionsChips', form)),
+    operator: get('edit_operator').value || '',
+    batteryId: get('edit_batteryId').value.trim(),
+    delaySec: get('edit_delaySec').value ? Number(get('edit_delaySec').value) : null,
+    commandRx: get('edit_commandRx').value || '',
+    notes: get('edit_entryNotes').value.trim()
+  };
+  try{
+    await apiRequest(`/api/shows/${show.id}/entries/${state.editingEntryRef.entryId}`, {method:'PUT', body: JSON.stringify(entryUpdate)});
+    const updatedShow = await apiRequest(`/api/shows/${show.id}`, {method:'GET'});
+    upsertShow(updatedShow);
+    renderGroups();
+    closeEditModal();
+    toast('Entry updated');
+  }catch(err){
+    console.error(err);
+    toast('Failed to update entry', true);
+  }
+}
+
+function buildEntryFieldsClone(entry, show){
+  const fields = [];
+  const wrap = (node, cls='col-3')=>{
+    const div = document.createElement('div');
+    div.className = cls;
+    div.appendChild(node);
+    return div;
+  };
+  const createLabelWrap = (id, labelText, node)=>{
+    const label = document.createElement('label');
+    label.setAttribute('for', id);
+    label.textContent = labelText;
+    const wrapper = document.createElement('div');
+    wrapper.appendChild(label);
+    node.id = id;
+    node.style.width = '100%';
+    node.style.minHeight = 'var(--tap-min)';
+    wrapper.appendChild(node);
+    return wrapper;
+  };
+  const unit = document.createElement('select');
+  const units = getDefaultUnits();
+  if(entry.unitId && !units.includes(entry.unitId)){
+    units.push(entry.unitId);
+  }
+  unit.innerHTML = '<option value="">Select</option>' + units.map(u=>`<option ${entry.unitId===u?'selected':''}>${u}</option>`).join('');
+  fields.push(wrap(createLabelWrap('edit_unitId', `${state.unitLabel} ID`, unit)));
+
+  const plannedSelect = document.createElement('select');
+  plannedSelect.innerHTML = optionsForYesNo(entry.planned);
+  fields.push(wrap(createLabelWrap('edit_planned', 'Planned to fly', plannedSelect)));
+
+  const launchedSelect = document.createElement('select');
+  launchedSelect.innerHTML = optionsForYesNo(entry.launched);
+  fields.push(wrap(createLabelWrap('edit_launched', 'Launched', launchedSelect)));
+
+  const pills = pillBuild(entry.status);
+  fields.push(wrap(pills, 'col-4'));
+
+  const prim = document.createElement('select');
+  prim.innerHTML = '<option value="">Select</option>' + PRIMARY_ISSUES.map(issue=>`<option ${entry.primaryIssue===issue?'selected':''}>${issue}</option>`).join('');
+  fields.push(wrap(createLabelWrap('edit_primaryIssue', 'Primary issue', prim), 'col-4'));
+
+  const sub = document.createElement('select');
+  const options = ISSUE_MAP[entry.primaryIssue] || [];
+  sub.innerHTML = '<option value="">N/A</option>' + options.map(opt=>`<option ${entry.subIssue===opt?'selected':''}>${opt}</option>`).join('');
+  fields.push(wrap(createLabelWrap('edit_subIssue', 'Sub-issue', sub), 'col-4'));
+
+  const other = document.createElement('input');
+  other.type = 'text';
+  other.value = entry.otherDetail || '';
+  fields.push(wrap(createLabelWrap('edit_otherDetail', 'Other detail', other), 'col-4'));
+
+  const sev = document.createElement('select');
+  sev.innerHTML = '<option value="">Select</option>' + ['Critical show stop','Major visible','Minor contained'].map(opt=>`<option ${entry.severity===opt?'selected':''}>${opt}</option>`).join('');
+  fields.push(wrap(createLabelWrap('edit_severity', 'Severity', sev), 'col-4'));
+
+  const root = document.createElement('select');
+  root.innerHTML = '<option value="">Select</option>' + ['Hardware','Software','Ops','Environment','Unknown'].map(opt=>`<option ${entry.rootCause===opt?'selected':''}>${opt}</option>`).join('');
+  fields.push(wrap(createLabelWrap('edit_rootCause', 'Root cause draft', root), 'col-4'));
+
+  const actionsWrap = document.createElement('div');
+  actionsWrap.className = 'actions-chips';
+  actionsWrap.id = 'edit_actionsChips';
+  renderActionsChips(actionsWrap, entry.actions || []);
+  const actionsContainer = document.createElement('div');
+  actionsContainer.className = 'col-12';
+  const actionsLabel = document.createElement('label');
+  actionsLabel.textContent = 'Actions taken';
+  actionsContainer.appendChild(actionsLabel);
+  actionsContainer.appendChild(actionsWrap);
+  fields.push(actionsContainer);
+
+  const operatorSelect = document.createElement('select');
+  const crew = [...new Set([...(show?.crew || []), ...(entry.operator ? [entry.operator] : []), ...DEFAULT_CREW])];
+  operatorSelect.innerHTML = '<option value="">Select</option>' + crew.map(name=>`<option ${entry.operator===name?'selected':''}>${escapeHtml(name)}</option>`).join('');
+  fields.push(wrap(createLabelWrap('edit_operator', 'Operator', operatorSelect)));
+
+  const battery = document.createElement('input');
+  battery.type = 'text';
+  battery.value = entry.batteryId || '';
+  fields.push(wrap(createLabelWrap('edit_batteryId', 'Battery ID', battery)));
+
+  const delay = document.createElement('input');
+  delay.type = 'number';
+  delay.step = '0.1';
+  delay.min = '0';
+  delay.value = entry.delaySec ?? '';
+  fields.push(wrap(createLabelWrap('edit_delaySec', 'Launch delay seconds', delay)));
+
+  const cmdRx = document.createElement('select');
+  cmdRx.innerHTML = '<option value="">Select</option>' + ['Yes','No'].map(opt=>`<option ${entry.commandRx===opt?'selected':''}>${opt}</option>`).join('');
+  fields.push(wrap(createLabelWrap('edit_commandRx', 'Command received', cmdRx)));
+
+  const notes = document.createElement('input');
+  notes.type = 'text';
+  notes.value = entry.notes || '';
+  fields.push(wrap(createLabelWrap('edit_entryNotes', 'Notes', notes), 'col-9'));
+
+  return fields;
+}
+
+function optionsForYesNo(selected){
+  return ['','Yes','No'].map(opt=> opt ? `<option ${selected===opt?'selected':''}>${opt}</option>` : '<option value="">Select</option>').join('');
+}
+
+function pillBuild(current){
+  const wrapper = document.createElement('div');
+  wrapper.className = 'pills';
+  STATUS.forEach(status=>{
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'pill';
+    btn.dataset.status = status;
+    btn.textContent = status;
+    btn.setAttribute('aria-pressed', status === current ? 'true' : 'false');
+    btn.addEventListener('click', ()=>{
+      qsa('.pill', wrapper).forEach(b=> b.setAttribute('aria-pressed', 'false'));
+      btn.setAttribute('aria-pressed', 'true');
+    });
+    if(status === 'Completed'){ btn.classList.add('completed'); }
+    if(status === 'No-launch'){ btn.classList.add('nolaunch'); }
+    if(status === 'Abort'){ btn.classList.add('abort'); }
+    wrapper.appendChild(btn);
+  });
+  return wrapper;
+}
+
+function pillGet(formRoot){
+  const btn = qsa('.pill', formRoot).find(b=>b.getAttribute('aria-pressed')==='true');
+  return btn ? btn.dataset.status : '';
+}
+
+function renderOperatorOptions(){
+  const show = getCurrentShow();
+  const names = new Set([...(show?.crew || []), ...DEFAULT_CREW]);
+  const current = operator.value;
+  operator.innerHTML = '<option value="">Select</option>' + Array.from(names).map(name=>`<option ${current===name?'selected':''}>${escapeHtml(name)}</option>`).join('');
+}
+
+function toggleConfig(open){
+  configBtn.setAttribute('aria-expanded', String(open));
+  configPanel.classList.toggle('open', open);
+  if(open){
+    configMessage.textContent = '';
+  }
+}
+
+async function onConfigSubmit(event){
+  event.preventDefault();
+  const payload = {
+    unitLabel: unitLabelSelect.value,
+    provider: providerSelect.value,
+    sql: {
+      filename: sqlFilename.value.trim()
+    },
+    coda: {
+      apiToken: codaToken.value.trim(),
+      docId: codaDoc.value.trim(),
+      tableId: codaTable.value.trim(),
+      showIdColumn: codaShowId.value.trim(),
+      payloadColumn: codaPayload.value.trim()
+    }
+  };
+  try{
+    const updated = await apiRequest('/api/config', {method:'PUT', body: JSON.stringify(payload)});
+    state.config = updated;
+    state.unitLabel = updated.unitLabel || 'Drone';
+    state.serverHost = updated.host || state.serverHost;
+    const nextPort = Number.parseInt(updated.port, 10);
+    state.serverPort = Number.isFinite(nextPort) ? nextPort : state.serverPort;
+    state.activeProvider = updated.provider || state.activeProvider || 'sql';
+    unitLabelSelect.value = state.unitLabel;
+    appTitle.textContent = state.unitLabel;
+    unitLabelEl.textContent = state.unitLabel;
+    setLanAddress();
+    setProviderBadge(state.activeProvider);
+    populateUnitOptions();
+    updateConnectionIndicator('loading');
+    await loadShows();
+    fillHeader(getCurrentShow());
+    renderGroups();
+    renderOperatorOptions();
+    configMessage.textContent = 'Settings saved. Provider restarted.';
+    toggleConfig(false);
+    toast('Settings updated');
+  }catch(err){
+    console.error(err);
+    configMessage.textContent = err.message || 'Failed to save settings';
+    toast('Failed to save settings', true);
+  }
+}
+
+function onProviderChange(){
+  const provider = providerSelect.value;
+  sqlFields.style.display = provider === 'sql' ? 'block' : 'none';
+  codaFields.style.display = provider === 'coda' ? 'block' : 'none';
+}
+
+function onExportCsv(){
+  const show = getCurrentShow();
+  if(!show){
+    toast('No current show', true);
+    return;
+  }
+  const headers = [
+    'showId','showDate','showTime','showLabel','crew','leadPilot','monkeyLead','showNotes','entryId','unitId','planned','launched','status','primaryIssue','subIssue','otherDetail','severity','rootCause','actions','operator','batteryId','delaySec','commandRx','notes'
+  ];
+  const rows = (show.entries||[]).map(entry=>[
+    show.id,
+    show.date || '',
+    show.time || '',
+    show.label || '',
+    (show.crew||[]).join('|'),
+    show.leadPilot || '',
+    show.monkeyLead || '',
+    show.notes || '',
+    entry.id,
+    entry.unitId || '',
+    entry.planned || '',
+    entry.launched || '',
+    entry.status || '',
+    entry.primaryIssue || '',
+    entry.subIssue || '',
+    entry.otherDetail || '',
+    entry.severity || '',
+    entry.rootCause || '',
+    (entry.actions||[]).join('|'),
+    entry.operator || '',
+    entry.batteryId || '',
+    entry.delaySec ?? '',
+    entry.commandRx || '',
+    entry.notes || ''
+  ]);
+  const csv = [headers.map(csvEscape).join(','), ...rows.map(row=>row.map(csvEscape).join(','))].join('\n');
+  downloadFile(csv, `${show.id}.csv`, 'text/csv');
+  toast('CSV exported');
+}
+
+function onExportJson(){
+  const show = getCurrentShow();
+  if(!show){
+    toast('No current show', true);
+    return;
+  }
+  const json = JSON.stringify(show, null, 2);
+  downloadFile(json, `${show.id}.json`, 'application/json');
+  toast('JSON exported');
+}
+
+function clearErrors(){
+  qsa('.error').forEach(e=> e.hidden = true);
+}
+
+function showError(id){
+  const el = document.getElementById(id);
+  if(el){
+    el.hidden = false;
+  }
+}
+
+function setLanAddress(){
+  if(!lanAddressEl){ return; }
+  const host = state.serverHost || '10.241.211.120';
+  const port = state.serverPort || 3000;
+  lanAddressEl.textContent = `http://${host}:${port}`;
+}
+
+function setProviderBadge(provider){
+  if(!providerBadge){ return; }
+  const normalized = (provider || '').toLowerCase();
+  providerBadge.classList.remove('provider-sql', 'provider-coda');
+  if(normalized === 'coda'){
+    providerBadge.classList.add('provider-coda');
+    providerBadge.textContent = 'Coda table';
+  }else{
+    providerBadge.classList.add('provider-sql');
+    providerBadge.textContent = 'SQL storage';
+  }
+  providerBadge.setAttribute('aria-label', `Active storage provider: ${providerBadge.textContent}`);
+}
+
+function updateConnectionIndicator(status){
+  if(!connectionStatusEl){ return; }
+  const host = state.serverHost || '10.241.211.120';
+  const port = state.serverPort || 3000;
+  const provider = (state.activeProvider || state.config?.provider || 'sql').toLowerCase();
+  const providerLabel = provider === 'coda' ? 'Coda table' : 'SQL storage';
+  setLanAddress();
+  setProviderBadge(provider);
+  connectionStatusEl.classList.remove('is-error', 'is-pending');
+  let message = '';
+  if(status === 'loading'){
+    message = `Refreshing data from ${host}:${port}…`;
+    connectionStatusEl.classList.add('is-pending');
+  }else if(status === 'error'){
+    message = `Unable to reach ${host}:${port}`;
+    connectionStatusEl.classList.add('is-error');
+  }else if(status === 'ready'){
+    message = `Listening on ${host}:${port}`;
+    connectionStatusEl.classList.add('is-pending');
+  }else{
+    message = `Connected to ${host}:${port}`;
+  }
+  connectionStatusEl.textContent = `${message} • ${providerLabel}`;
+}
+
+function toast(message, isError){
+  if(!toastEl){ return; }
+  toastEl.textContent = message;
+  toastEl.classList.add('show');
+  toastEl.style.borderColor = isError ? 'var(--danger)' : 'var(--border)';
+  setTimeout(()=> toastEl.classList.remove('show'), 2200);
+}
+
+function downloadFile(content, filename, type){
+  const blob = new Blob([content], {type: type || 'application/octet-stream'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(()=> URL.revokeObjectURL(url), 500);
+}
+
+function csvEscape(value){
+  if(value == null){
+    return '';
+  }
+  const str = String(value);
+  if(/[",\r\n]/.test(str)){
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function adjustContainerBottomPadding(){
+  const container = document.querySelector('.container');
+  const footer = document.querySelector('.sticky-footer');
+  if(!container || !footer){ return; }
+  const footerHeight = Math.ceil(footer.getBoundingClientRect().height);
+  container.style.paddingBottom = `${footerHeight + 12}px`;
+}
+
+function getDefaultUnits(){
+  if(state.unitLabel === 'Monkey'){
+    return Array.from({length: 12}, (_, i)=> String(i+1));
+  }
+  return Array.from({length: 12}, (_, i)=> `D${i+1}`);
+}
+
+function formatDateUS(dateStr){
+  if(!dateStr || !dateStr.includes('-')){
+    return dateStr || '';
+  }
+  const [y,m,d] = dateStr.split('-');
+  return `${m}-${d}-${y}`;
+}
+
+function formatTime12Hour(timeStr){
+  if(!timeStr || !timeStr.includes(':')){
+    return timeStr || '';
+  }
+  const [h, m] = timeStr.split(':');
+  let hour = parseInt(h, 10);
+  const suffix = hour >= 12 ? 'PM' : 'AM';
+  if(hour === 0){ hour = 12; }
+  if(hour > 12){ hour -= 12; }
+  return `${hour}:${m} ${suffix}`;
+}
+
+function escapeHtml(str){
+  return String(str || '').replace(/[&<>"']/g, ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+}
+
+function debounce(fn, wait){
+  let timeout;
+  return function(...args){
+    clearTimeout(timeout);
+    timeout = setTimeout(()=> fn.apply(this, args), wait);
+  };
+}
+
+async function apiRequest(url, options){
+  const opts = options || {};
+  if(opts.body && typeof opts.body !== 'string'){
+    opts.body = JSON.stringify(opts.body);
+  }
+  opts.headers = Object.assign({'Content-Type': 'application/json'}, opts.headers || {});
+  const res = await fetch(url, opts);
+  if(res.status === 204){
+    return null;
+  }
+  let data = null;
+  try{
+    data = await res.json();
+  }catch(err){
+    data = null;
+  }
+  if(!res.ok){
+    const message = data && data.error ? data.error : `Request failed (${res.status})`;
+    throw new Error(message);
+  }
+  return data;
+}
+
+function initCrewChipInput(container, initial, onChange){
+  container.innerHTML = '';
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = 'Type name and press Enter';
+  const names = [...initial];
+  const renderChip = name =>{
+    const chip = document.createElement('span');
+    chip.className = 'chip';
+    chip.innerHTML = `<span>${escapeHtml(name)}</span><button class="x" aria-label="Remove">×</button>`;
+    qs('.x', chip).addEventListener('click', e=>{
+      e.stopPropagation();
+      const idx = names.indexOf(name);
+      if(idx >=0){
+        names.splice(idx,1);
+        chip.remove();
+        onChange([...names]);
+      }
+    });
+    return chip;
+  };
+  names.forEach(name=> container.appendChild(renderChip(name)));
+  container.appendChild(input);
+  input.addEventListener('keydown', e=>{
+    if(e.key === 'Enter' || e.key === ','){
+      e.preventDefault();
+      const value = input.value.trim();
+      if(value && !names.includes(value)){
+        names.push(value);
+        container.insertBefore(renderChip(value), input);
+        onChange([...names]);
+      }
+      input.value = '';
+    }
+  });
+  container.addEventListener('click', ()=> input.focus());
+}
+
+function getShowById(id){
+  return state.shows.find(s=>s.id===id) || null;
+}
+
+function el(id){
+  return document.getElementById(id);
+}
+
+function qs(selector, root=document){
+  return root.querySelector(selector);
+}
+
+function qsa(selector, root=document){
+  return Array.from(root.querySelectorAll(selector));
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,261 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Drone Tracker</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <div class="topbar" role="banner">
+    <div class="toolbar">
+      <div class="row">
+        <button id="configBtn" class="btn icon-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings">⚙️</button>
+        <h1><span id="appTitle">Drone</span> Tracker</h1>
+      </div>
+      <div class="subtitle">Per show run data entry. Backed by Express API with modular storage.</div>
+    </div>
+  </div>
+
+  <div id="configPanel" class="config" role="dialog" aria-modal="true" aria-labelledby="configTitle">
+    <div class="toolbar">
+      <h2 id="configTitle">Application settings</h2>
+      <button id="closeConfig" class="btn icon-btn" title="Close settings">✖️</button>
+    </div>
+    <form id="configForm" class="grid">
+      <div class="col-12">
+        <label for="unitLabelSelect">Unit label</label>
+        <select id="unitLabelSelect" name="unitLabel">
+          <option value="Drone">Drone</option>
+          <option value="Monkey">Monkey</option>
+        </select>
+        <p class="help">Controls how units are referenced across the UI.</p>
+      </div>
+      <div class="col-12">
+        <label for="providerSelect">Storage provider</label>
+        <select id="providerSelect" name="provider">
+          <option value="sql">SQL (SQLite)</option>
+          <option value="coda">Coda Table</option>
+        </select>
+      </div>
+      <fieldset id="sqlFields" class="col-12 provider-fields">
+        <legend>SQL configuration</legend>
+        <label for="sqlFilename">SQLite database file</label>
+        <input id="sqlFilename" type="text" placeholder="data/monkey-tracker.sqlite" />
+        <p class="help">The server will create the file if it does not exist.</p>
+      </fieldset>
+      <fieldset id="codaFields" class="col-12 provider-fields">
+        <legend>Coda configuration</legend>
+        <label for="codaToken">API token</label>
+        <input id="codaToken" type="password" autocomplete="off" placeholder="Coda API token" />
+        <label for="codaDoc">Doc ID</label>
+        <input id="codaDoc" type="text" autocomplete="off" placeholder="doc_XXXX" />
+        <label for="codaTable">Table ID</label>
+        <input id="codaTable" type="text" autocomplete="off" placeholder="table_XXXX" />
+        <label for="codaShowId">Show ID column name</label>
+        <input id="codaShowId" type="text" autocomplete="off" placeholder="Show ID" />
+        <label for="codaPayload">Payload column name</label>
+        <input id="codaPayload" type="text" autocomplete="off" placeholder="Payload" />
+        <p class="help">The payload column should be a text field used to store JSON.</p>
+      </fieldset>
+      <div class="col-12 row" style="justify-content: flex-end; gap: 10px;">
+        <button type="button" id="cancelConfig" class="btn ghost">Cancel</button>
+        <button type="submit" class="btn primary">Save settings</button>
+      </div>
+      <div class="col-12">
+        <div id="configMessage" role="status" aria-live="polite" class="help"></div>
+      </div>
+    </form>
+  </div>
+
+  <div class="container" role="main">
+    <section class="panel info-panel" aria-labelledby="welcomeTitle">
+      <div class="info-grid">
+        <div class="info-copy">
+          <h2 id="welcomeTitle">Live show dashboard</h2>
+          <p class="lead">Capture each run in real time. Start a new show, log entries, and keep everyone aligned.</p>
+          <ul class="quick-hints" role="list">
+            <li><strong>New Show</strong> creates a fresh record with default crew and units.</li>
+            <li><strong>Duplicate Current Show</strong> reuses the crew roster for the next run.</li>
+            <li>Switch between SQL and Coda storage at any time from the ⚙️ settings menu.</li>
+          </ul>
+        </div>
+        <div class="lan-status" aria-live="polite">
+          <div id="connectionStatus" class="connection-status is-pending">Checking server…</div>
+          <div class="lan-controls">
+            <span id="providerBadge" class="badge provider-sql" aria-label="Active storage provider">SQL storage</span>
+            <button id="refreshShows" type="button" class="btn ghost">Refresh data</button>
+          </div>
+          <div class="lan-target">LAN URL: <code id="lanAddress">http://10.241.211.120:3000</code></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel" aria-labelledby="showHeaderTitle">
+      <h2 id="showHeaderTitle">Show header</h2>
+      <div class="grid">
+        <div class="col-3">
+          <label for="showDate">Date</label>
+          <input id="showDate" type="date" autocomplete="off" />
+        </div>
+        <div class="col-3">
+          <label for="showTime">Show start time</label>
+          <input id="showTime" type="time" />
+        </div>
+        <div class="col-6">
+          <label for="showLabel">Show label or number</label>
+          <input id="showLabel" type="text" placeholder="e.g., 7pm Main" />
+        </div>
+        <div class="col-6">
+          <label>Crew on duty <span class="help">(press Enter to add name)</span></label>
+          <div id="crewInput" class="chip-input" aria-label="Crew on duty input"></div>
+        </div>
+        <div class="col-3">
+          <label for="leadPilot">Lead Pilot</label>
+          <select id="leadPilot"></select>
+        </div>
+        <div class="col-3">
+          <label for="monkeyLead">Monkey Lead</label>
+          <select id="monkeyLead"></select>
+        </div>
+        <div class="col-12">
+          <label for="showNotes">Notes for the show</label>
+          <textarea id="showNotes" placeholder="High-level notes"></textarea>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel" aria-labelledby="entryTitle">
+      <h2 id="entryTitle">Entry form</h2>
+      <div class="grid" id="entryForm">
+        <div class="col-2">
+          <label for="unitId"><span id="unitLabel">Monkey</span> ID</label>
+          <select id="unitId"></select>
+          <div class="error" id="errUnit" hidden>Required</div>
+        </div>
+        <div class="col-2">
+          <label for="planned">Planned to fly</label>
+          <select id="planned">
+            <option value="">Select</option>
+            <option>Yes</option>
+            <option>No</option>
+          </select>
+          <div class="error" id="errPlanned" hidden>Required</div>
+        </div>
+        <div class="col-2">
+          <label for="launched">Launched</label>
+          <select id="launched">
+            <option value="">Select</option>
+            <option>Yes</option>
+            <option>No</option>
+          </select>
+          <div class="error" id="errLaunched" hidden>Required</div>
+        </div>
+        <div class="col-4">
+          <label>Status</label>
+          <div class="pills" role="group" aria-label="Status">
+            <button type="button" class="pill completed" id="stCompleted" data-status="Completed" aria-pressed="false"><span class="status-dot dot-success"></span>Completed</button>
+            <button type="button" class="pill nolaunch" id="stNoLaunch" data-status="No-launch" aria-pressed="false"><span class="status-dot dot-danger"></span>No-launch</button>
+            <button type="button" class="pill abort" id="stAbort" data-status="Abort" aria-pressed="false"><span class="status-dot dot-warn"></span>Abort</button>
+          </div>
+          <div class="error" id="errStatus" hidden>Required</div>
+        </div>
+        <div class="col-4 issue-block hidden">
+          <label for="primaryIssue">Primary issue</label>
+          <select id="primaryIssue"></select>
+          <div class="error" id="errPrimary" hidden>Required</div>
+        </div>
+        <div class="col-4 issue-block hidden">
+          <label for="subIssue">Sub-issue</label>
+          <select id="subIssue"></select>
+        </div>
+        <div class="col-4 issue-block hidden" id="otherDetailWrap">
+          <label for="otherDetail">Other detail</label>
+          <input id="otherDetail" type="text" placeholder="Short detail" />
+          <div class="error" id="errOther" hidden>Required</div>
+        </div>
+        <div class="col-4 issue-block hidden">
+          <label for="severity">Severity</label>
+          <select id="severity">
+            <option value="">Select</option>
+            <option>Critical show stop</option>
+            <option>Major visible</option>
+            <option>Minor contained</option>
+          </select>
+          <div class="error" id="errSeverity" hidden>Required</div>
+        </div>
+        <div class="col-4 issue-block hidden">
+          <label for="rootCause">Root cause draft</label>
+          <select id="rootCause">
+            <option value="">Select</option>
+            <option>Hardware</option>
+            <option>Software</option>
+            <option>Ops</option>
+            <option>Environment</option>
+            <option>Unknown</option>
+          </select>
+        </div>
+        <div class="col-12 issue-block hidden">
+          <label>Actions taken</label>
+          <div class="actions-chips" id="actionsChips" role="group" aria-label="Actions taken"></div>
+        </div>
+        <div class="col-3">
+          <label for="operator">Operator</label>
+          <select id="operator"></select>
+        </div>
+        <div class="col-3">
+          <label for="batteryId">Battery ID</label>
+          <input id="batteryId" type="text" placeholder="e.g., B-12" />
+        </div>
+        <div class="col-3">
+          <label for="delaySec">Launch delay seconds</label>
+          <input id="delaySec" type="number" step="0.1" min="0" placeholder="0.0" />
+          <div class="error" id="errDelay" hidden>Must be a non-negative number</div>
+        </div>
+        <div class="col-3">
+          <label for="commandRx">Command received</label>
+          <select id="commandRx">
+            <option value="">Select</option>
+            <option>Yes</option>
+            <option>No</option>
+          </select>
+        </div>
+        <div class="col-9">
+          <label for="entryNotes">Notes</label>
+          <input id="entryNotes" type="text" placeholder="Short note" />
+        </div>
+      </div>
+    </section>
+
+    <section id="groups"></section>
+  </div>
+
+  <div class="sticky-footer" role="contentinfo">
+    <div class="footer-grid">
+      <button id="newShow" class="btn span-3">New Show</button>
+      <button id="dupShow" class="btn span-3">Duplicate Current Show</button>
+      <button id="addLine" class="btn primary span-3">Add line</button>
+      <button id="exportCsv" class="btn ghost span-3">Export CSV</button>
+      <button id="exportJson" class="btn ghost span-3">Export JSON</button>
+    </div>
+  </div>
+
+  <div id="editModal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="editTitle">
+    <div class="modal">
+      <div class="toolbar">
+        <h2 id="editTitle">Edit entry</h2>
+        <button id="closeEdit" class="btn icon-btn" title="Close edit">✖️</button>
+      </div>
+      <form id="editForm" class="grid"></form>
+      <div class="sep"></div>
+      <div class="row" style="justify-content:flex-end;gap:10px;">
+        <button type="button" id="saveEdit" class="btn primary">Save changes</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+  <script src="./app.js" type="module"></script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,266 @@
+:root{
+  --bg:#0e0f12;
+  --panel:#16181d;
+  --muted:#1f232b;
+  --text:#e8e8ea;
+  --text-dim:#a7acb8;
+  --primary:#4aa3ff;
+  --primary-2:#2e7bd1;
+  --success:#1fc67a;
+  --warn:#ffc857;
+  --danger:#ff5d5d;
+  --focus:#30c4ff;
+  --input:#0f1115;
+  --chip:#ffbe3f;
+  --border:#26365a;
+  --shadow: 0 10px 30px rgba(0,0,0,.35);
+  --radius:14px;
+  --radius-sm:10px;
+  --radius-lg:18px;
+  --gap:12px;
+  --tap-min:44px;
+  --fz:16px;
+}
+*{box-sizing:border-box}
+html,body{height:100%}
+body{
+  margin:0;
+  background:var(--bg);
+  color:var(--text);
+  font:500 var(--fz)/1.35 system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
+  -webkit-font-smoothing:antialiased;
+  text-rendering:optimizeLegibility;
+}
+h1,h2,h3{margin:0 0 8px}
+h1{font-size:22px}
+h2{font-size:18px;color:var(--text-dim)}
+a{color:var(--primary);text-decoration:none}
+.container{
+  max-width:1100px;
+  margin:0 auto;
+  padding:14px 16px 120px;
+}
+.topbar{
+  position:sticky;top:0;z-index:50;
+  background:linear-gradient(to bottom, rgba(14,15,18,.95), rgba(14,15,18,.85) 60%, transparent);
+  backdrop-filter:saturate(1.2) blur(8px);
+  padding:10px 16px 6px;
+  border-bottom:1px solid var(--border);
+}
+.row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+.grow{flex:1}
+.badge{
+  background:var(--chip); color:var(--text-dim); padding:6px 10px; border-radius:999px; font-size:12px; border:1px solid var(--border)
+}
+.panel{
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  box-shadow:var(--shadow);
+  padding:14px;
+  margin-top:14px;
+}
+.info-panel{padding:20px;display:flex}
+.info-grid{display:flex;flex-direction:column;gap:18px;width:100%}
+.info-copy{flex:2}
+.lead{color:var(--text);font-size:15px;margin:0 0 12px;line-height:1.5}
+.quick-hints{margin:0;padding-left:20px;color:var(--text-dim);font-size:14px;line-height:1.5}
+.quick-hints li{margin-bottom:6px}
+.quick-hints strong{color:var(--text)}
+.lan-status{background:var(--muted);border:1px solid var(--border);border-radius:var(--radius-sm);padding:16px;display:flex;flex-direction:column;gap:10px;align-self:flex-start;min-width:240px}
+.connection-status{font-size:14px;color:var(--success);display:flex;align-items:center;gap:8px;font-weight:700}
+.connection-status::before{content:'•';font-size:18px;color:currentColor}
+.connection-status.is-pending{color:var(--warn)}
+.connection-status.is-error{color:var(--danger)}
+.lan-controls{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+.lan-controls .btn{min-height:36px;padding:10px 12px}
+.lan-target{font-size:13px;color:var(--text-dim)}
+.lan-target code{background:#10131a;padding:4px 6px;border-radius:8px;color:var(--text);border:1px solid var(--border)}
+.badge.provider-sql{background:rgba(74,163,255,.18);color:#aed4ff;border-color:rgba(74,163,255,.55)}
+.badge.provider-coda{background:rgba(64,255,210,.18);color:#b4ffe8;border-color:rgba(64,255,210,.55)}
+.btn[disabled]{opacity:.6;cursor:not-allowed}
+@media (min-width:900px){
+  .info-grid{flex-direction:row;justify-content:space-between;align-items:flex-start}
+  .info-copy{max-width:60%}
+  .lan-status{width:280px}
+}
+.grid{
+  display:grid; gap:10px;
+  grid-template-columns: repeat(12, 1fr);
+}
+.col-12{grid-column:span 12}
+.col-6{grid-column:span 6}
+.col-4{grid-column:span 4}
+.col-3{grid-column:span 3}
+.col-2{grid-column:span 2}
+@media (max-width:900px){
+  .col-6,.col-4,.col-3,.col-2{grid-column:span 12}
+}
+label{font-size:12px;color:var(--text-dim);display:block;margin:4px 0 6px}
+input, select, textarea{
+  width:100%;
+  background:var(--input);
+  color:var(--text);
+  border:1px solid var(--border);
+  border-radius:10px;
+  padding:12px 12px;
+  min-height:var(--tap-min);
+  outline:none;
+  transition:.15s border, .15s box-shadow, .15s background;
+  font:inherit;
+}
+#showDate, #showTime{
+  background:
+    linear-gradient(to right, rgba(255,255,255,0) 0%, rgba(255,255,255,0) 64%, rgba(255,255,255,.08) 82%, rgba(255,255,255,.16) 100%),
+    var(--input);
+  background-repeat:no-repeat;
+  background-clip: padding-box;
+}
+textarea{min-height:84px; resize:vertical}
+input:focus, select:focus, textarea:focus, .btn:focus-visible, .chip-input input:focus{
+  border-color:var(--focus);
+  box-shadow:0 0 0 3px rgba(154, 210, 255, 0.95);
+}
+.btn{
+  background:var(--muted);
+  color:var(--text);
+  border:1px solid var(--border);
+  border-radius:12px;
+  padding:12px 14px;
+  min-height:var(--tap-min);
+  font-weight:700;
+  cursor:pointer;
+  transition:.15s transform, .15s background, .15s border-color;
+  user-select:none;
+  -webkit-tap-highlight-color:transparent;
+}
+.btn:hover{background:#232733}
+.btn:active{transform:translateY(1px)}
+.btn.primary{background:var(--primary); border-color:var(--primary-2); color:#041423}
+.btn.ghost{background:transparent}
+.btn.icon-btn{width:var(--tap-min); height:var(--tap-min); display:inline-grid; place-items:center; border-radius:12px;}
+.sticky-footer{
+  position:fixed; inset:auto 0 0 0; z-index:60;
+  background:linear-gradient(to top, rgba(22,24,29,.98), rgba(25, 30, 41, 0.96) 60%, rgba(29, 34, 47, 0.92));
+  backdrop-filter:saturate(1.2) blur(8px);
+  padding:10px 16px calc(16px + env(safe-area-inset-bottom));
+  border-top:1px solid var(--border);
+}
+.footer-grid{
+  display:grid; gap:10px;
+  grid-template-columns: repeat(12, 1fr);
+  max-width:1100px;margin:0 auto;
+}
+.footer-grid .btn{min-width:100%}
+.footer-grid .span-2{grid-column:span 2}
+.footer-grid .span-3{grid-column:span 3}
+.footer-grid .span-4{grid-column:span 4}
+@media (max-width:1100px){
+  .footer-grid .span-2,.footer-grid .span-3,.footer-grid .span-4{grid-column:span 6}
+}
+@media (max-width:520px){
+  .footer-grid .span-2,.footer-grid .span-3,.footer-grid .span-4{grid-column:span 12}
+}
+
+.chips{display:flex;gap:8px;flex-wrap:wrap}
+.chip{
+  background:var(--chip); border:1px solid var(--border);
+  border-radius:999px; padding:8px 12px; min-height:var(--tap-min);
+  display:inline-flex; align-items:center; gap:8px; color:var(--text);
+}
+.chip .x{background:transparent; border:none; color:var(--text-dim); cursor:pointer; font-size:18px; line-height:1; padding:0; width:24px; height:24px}
+.chip-input{
+  display:flex; align-items:center; flex-wrap:wrap; gap:8px; background:var(--input); border:1px solid var(--border);
+  border-radius:10px; padding:8px; min-height:var(--tap-min);
+}
+.chip-input input{
+  border:none;background:transparent; min-height:32px; padding:8px;
+  flex:1; outline:none;
+}
+
+.pills{display:flex; gap:8px; flex-wrap:wrap}
+.pill{
+  border:1px solid var(--border); background:var(--chip); color:var(--text); border-radius:999px; padding:10px 14px;
+  cursor:pointer; user-select:none; min-height:var(--tap-min); display:inline-flex; align-items:center; font-weight:700
+}
+.pill[aria-pressed="true"]{outline:4px solid rgba(154,209,255,.6); border-color:var(--focus); box-shadow:0 0 0 1px var(--focus)}
+.pill.completed{background:rgba(31,198,122,.16); border-color:rgba(31,198,122,.55)}
+.pill.nolaunch{background:rgba(255,93,93,.16); border-color:rgba(255,93,93,.55)}
+.pill.abort{background:rgba(255,200,87,.16); border-color:rgba(255,200,87,.55)}
+
+.hidden{display:none !important}
+.error{color:#ff9b9b; font-size:12px; margin-top:6px}
+.help{color:var(--text-dim); font-size:12px}
+
+.details.group{background:var(--panel); border:1px solid var(--border); border-radius:var(--radius); margin-top:12px; overflow:hidden}
+
+details.group > summary{
+  list-style:none; cursor:pointer; padding:14px; background:linear-gradient(180deg, rgba(255,255,255,.02), transparent);
+  display:flex; align-items:center; justify-content:space-between; gap:10px
+}
+details.group[open] > summary{border-bottom:1px solid var(--border)}
+summary::-webkit-details-marker{display:none}
+.group-title{font-weight:800}
+.metrics{display:flex;gap:10px;flex-wrap:wrap;padding:10px 14px;background:#12141a}
+.metric{
+  background:var(--muted); border:1px solid var(--border); border-radius:12px; padding:8px 10px; font-size:13px; color:var(--text-dim)
+}
+.rows{display:grid; gap:8px; padding:12px}
+.rowcard{
+  display:grid; gap:8px; grid-template-columns: 50px 78px 100px 96px 1fr 120px 1fr 44px;
+  background:#13161c; border:1px solid var(--border); border-radius:12px; padding:10px; align-items:center
+}
+@media (max-width:1000px){
+  .rowcard{grid-template-columns:1fr 1fr; grid-auto-rows:auto}
+}
+.status-dot{width:10px;height:10px;border-radius:999px;display:inline-block;margin-right:8px}
+.dot-success{background:var(--success)}
+.dot-warn{background:var(--warn)}
+.dot-danger{background:var(--danger)}
+
+.menu{position:relative}
+.menu-btn{background:var(--muted);border:1px solid var(--border); border-radius:10px; width:36px;height:36px; display:grid;place-items:center; cursor:pointer}
+.menu-list{
+  position:absolute; right:0; top:44px; background:#0f1217; border:1px solid var(--border); border-radius:12px; min-width:160px; z-index:10; box-shadow:var(--shadow);
+  display:none
+}
+.menu[open] .menu-list{display:block}
+.menu-item{display:block;width:100%; text-align:left; padding:12px 14px; background:transparent; border:0; color:var(--text); cursor:pointer}
+.menu-item:hover{background:#171b23}
+
+.modal-backdrop{
+  position:fixed; inset:0; background:rgba(0,0,0,.55); display:none; align-items:center; justify-content:center; z-index:80; padding:16px
+}
+.modal{background:var(--panel); border:1px solid var(--border); border-radius:var(--radius-lg); width:min(820px, 100%); max-height:90vh; overflow:auto; padding:16px}
+.modal-backdrop.open{display:flex}
+
+.toast{
+  position:fixed; left:50%; bottom:92px; transform:translateX(-50%);
+  background:#0f131a; color:var(--text); border:1px solid var(--border); border-radius:999px; padding:12px 16px; z-index:100;
+  box-shadow:var(--shadow); display:none
+}
+.toast.show{display:block; animation:fade .2s ease}
+@keyframes fade{from{opacity:0; transform:translateX(-50%) translateY(6px)} to{opacity:1; transform:translateX(-50%) translateY(0)}}
+
+.toolbar{display:flex; gap:10px; align-items:center; justify-content:space-between}
+.subtitle{color:var(--text-dim)}
+.sep{height:1px;background:var(--border);margin:10px 0}
+.config{
+  position:fixed; right:16px; top:54px; width:min(420px, 92vw); background:var(--panel); border:1px solid var(--border);
+  border-radius:16px; padding:14px; z-index:70; display:none; box-shadow:var(--shadow)
+}
+.config.open{display:block}
+.provider-fields{border:1px solid var(--border); border-radius:12px; padding:12px}
+.provider-fields legend{font-weight:700}
+.switch{display:inline-flex; align-items:center; gap:8px}
+.switch input{width:auto; min-height:auto}
+.inline{display:flex; gap:8px; align-items:center; flex-wrap:wrap}
+.actions-chips{display:flex; gap:8px; flex-wrap:wrap}
+.action-chip{
+  border:1px solid var(--border); border-radius:999px; padding:8px 12px; background:var(--chip); cursor:pointer; user-select:none
+}
+.action-chip[aria-pressed="true"]{outline:3px solid rgba(154,209,255,.25); border-color:var(--focus)}
+.kbd{font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; background:#0d0f14; border:1px solid var(--border); padding:2px 6px; border-radius:6px; color:var(--text-dim)}
+.sr-only{position:absolute;left:-10000px;top:auto;width:1px;height:1px;overflow:hidden}
+
+#configMessage{min-height:20px}

--- a/server/configStore.js
+++ b/server/configStore.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_FILE = path.join(__dirname, '..', 'config', 'app-config.json');
+const DEFAULT_HOST = process.env.HOST || process.env.LISTEN_HOST || '10.241.211.120';
+const DEFAULT_PORT = Number.isFinite(parseInt(process.env.PORT, 10)) ? parseInt(process.env.PORT, 10) : 3000;
+const DEFAULT_CONFIG = {
+  host: DEFAULT_HOST,
+  port: DEFAULT_PORT,
+  unitLabel: 'Drone',
+  provider: 'sql',
+  sql: {
+    filename: path.join(process.cwd(), 'data', 'monkey-tracker.sqlite')
+  },
+  coda: {
+    apiToken: '',
+    docId: '',
+    tableId: '',
+    showIdColumn: 'Show ID',
+    payloadColumn: 'Payload'
+  }
+};
+
+function ensureConfigFile(){
+  const dir = path.dirname(CONFIG_FILE);
+  if(!fs.existsSync(dir)){
+    fs.mkdirSync(dir, {recursive: true});
+  }
+  if(!fs.existsSync(CONFIG_FILE)){
+    fs.writeFileSync(CONFIG_FILE, JSON.stringify(DEFAULT_CONFIG, null, 2));
+  }
+}
+
+function loadConfig(){
+  ensureConfigFile();
+  try{
+    const raw = fs.readFileSync(CONFIG_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    return {
+      ...DEFAULT_CONFIG,
+      ...parsed,
+      sql: {...DEFAULT_CONFIG.sql, ...(parsed.sql || {})},
+      coda: {...DEFAULT_CONFIG.coda, ...(parsed.coda || {})},
+      host: parsed.host || DEFAULT_CONFIG.host,
+      port: Number.isFinite(parseInt(parsed.port, 10)) ? parseInt(parsed.port, 10) : DEFAULT_CONFIG.port
+    };
+  }catch(err){
+    console.error('Failed to load config. Falling back to defaults.', err);
+    return {...DEFAULT_CONFIG};
+  }
+}
+
+function saveConfig(config){
+  ensureConfigFile();
+  const merged = {
+    ...DEFAULT_CONFIG,
+    ...config,
+    sql: {...DEFAULT_CONFIG.sql, ...(config.sql || {})},
+    coda: {...DEFAULT_CONFIG.coda, ...(config.coda || {})}
+  };
+  merged.host = merged.host || DEFAULT_CONFIG.host;
+  merged.port = Number.isFinite(parseInt(merged.port, 10)) ? parseInt(merged.port, 10) : DEFAULT_CONFIG.port;
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(merged, null, 2));
+  return merged;
+}
+
+module.exports = {
+  loadConfig,
+  saveConfig,
+  defaultConfig: DEFAULT_CONFIG
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,175 @@
+const path = require('path');
+const express = require('express');
+const morgan = require('morgan');
+const { loadConfig, saveConfig } = require('./configStore');
+const { initProvider, getProvider, getProviderName } = require('./storage');
+
+async function bootstrap(){
+  const app = express();
+  let config = loadConfig();
+  let configuredHost = config.host || '10.241.211.120';
+  let configuredPort = config.port || 3000;
+  const envPort = Number.parseInt(process.env.PORT, 10);
+  const envHost = process.env.HOST || process.env.LISTEN_HOST;
+  let boundPort = Number.isFinite(envPort) ? envPort : configuredPort;
+  let boundHost = envHost || configuredHost;
+  let serverInstance = null;
+  await initProvider(config);
+
+  app.use(express.json({limit: '2mb'}));
+  app.use(morgan('dev'));
+  app.use(express.static(path.join(__dirname, '..', 'public')));
+
+  function asyncHandler(fn){
+    return (req, res, next)=>{
+      Promise.resolve(fn(req, res, next)).catch(next);
+    };
+  }
+
+  app.get('/api/health', (req, res)=>{
+    res.json({
+      status: 'ok',
+      provider: getProviderName(),
+      host: configuredHost,
+      port: configuredPort,
+      boundHost,
+      boundPort
+    });
+  });
+
+  app.get('/api/config', (req, res)=>{
+    res.json(config);
+  });
+
+  app.put('/api/config', asyncHandler(async (req, res)=>{
+    const nextConfig = saveConfig(req.body || {});
+    await initProvider(nextConfig);
+    config = nextConfig;
+    configuredHost = config.host || configuredHost;
+    configuredPort = config.port || configuredPort;
+    if(!envHost && configuredHost !== boundHost){
+      console.warn(`Configured host updated to ${configuredHost}. Restart the server to bind to the new address.`);
+    }
+    if(!Number.isFinite(envPort) && configuredPort !== boundPort){
+      console.warn(`Configured port updated to ${configuredPort}. Restart the server to bind to the new port.`);
+    }
+    res.json(config);
+  }));
+
+  app.get('/api/shows', asyncHandler(async (req, res)=>{
+    const provider = getProvider();
+    const shows = await provider.listShows();
+    res.json({provider: getProviderName(), shows});
+  }));
+
+  app.post('/api/shows', asyncHandler(async (req, res)=>{
+    const provider = getProvider();
+    const show = await provider.createShow(req.body || {});
+    res.status(201).json(show);
+  }));
+
+  app.get('/api/shows/:id', asyncHandler(async (req, res)=>{
+    const provider = getProvider();
+    const show = await provider.getShow(req.params.id);
+    if(!show){
+      res.status(404).json({error: 'Show not found'});
+      return;
+    }
+    res.json(show);
+  }));
+
+  app.put('/api/shows/:id', asyncHandler(async (req, res)=>{
+    const provider = getProvider();
+    const show = await provider.updateShow(req.params.id, req.body || {});
+    if(!show){
+      res.status(404).json({error: 'Show not found'});
+      return;
+    }
+    res.json(show);
+  }));
+
+  app.delete('/api/shows/:id', asyncHandler(async (req, res)=>{
+    const provider = getProvider();
+    const existing = await provider.getShow(req.params.id);
+    if(!existing){
+      res.status(404).json({error: 'Show not found'});
+      return;
+    }
+    await provider.deleteShow(req.params.id);
+    res.status(204).end();
+  }));
+
+  app.post('/api/shows/:id/entries', asyncHandler(async (req, res)=>{
+    const provider = getProvider();
+    const entry = await provider.addEntry(req.params.id, req.body || {});
+    if(!entry){
+      res.status(404).json({error: 'Show not found'});
+      return;
+    }
+    res.status(201).json(entry);
+  }));
+
+  app.put('/api/shows/:id/entries/:entryId', asyncHandler(async (req, res)=>{
+    const provider = getProvider();
+    const entry = await provider.updateEntry(req.params.id, req.params.entryId, req.body || {});
+    if(!entry){
+      res.status(404).json({error: 'Entry not found'});
+      return;
+    }
+    res.json(entry);
+  }));
+
+  app.delete('/api/shows/:id/entries/:entryId', asyncHandler(async (req, res)=>{
+    const provider = getProvider();
+    const result = await provider.deleteEntry(req.params.id, req.params.entryId);
+    if(!result){
+      res.status(404).json({error: 'Entry not found'});
+      return;
+    }
+    res.status(204).end();
+  }));
+
+  // Serve index.html for any non-API request (client-side routing support)
+  app.get(/^(?!\/api\/).*/, (req, res)=>{
+    res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
+  });
+
+  app.use((err, req, res, next)=>{ // eslint-disable-line no-unused-vars
+    console.error(err);
+    if(err.message && err.message.includes('Coda provider is not fully configured')){
+      res.status(400).json({error: err.message});
+      return;
+    }
+    res.status(500).json({error: 'Internal server error', detail: err.message});
+  });
+
+  function handleListenError(err){
+    if(err.code === 'EADDRNOTAVAIL' && !envHost && boundHost !== '0.0.0.0'){
+      console.warn(`Address ${boundHost} is not available on this machine. Falling back to 0.0.0.0.`);
+      serverInstance?.off('error', handleListenError);
+      boundHost = '0.0.0.0';
+      startListening(boundHost);
+      return;
+    }
+    console.error('Failed to bind server', err);
+    process.exit(1);
+  }
+
+  function startListening(targetHost){
+    serverInstance = app.listen(boundPort, targetHost, ()=>{
+      console.log(`Server listening on http://${targetHost}:${boundPort}`);
+      if(targetHost !== configuredHost){
+        console.log(`Configured LAN URL: http://${configuredHost}:${configuredPort}`);
+      }
+      console.log('Press Ctrl+C to stop the server.');
+    });
+    serverInstance.on('error', handleListenError);
+  }
+
+  startListening(boundHost);
+}
+
+bootstrap().catch(err=>{
+  console.error('Failed to start server', err);
+  process.exit(1);
+});

--- a/server/storage/codaProvider.js
+++ b/server/storage/codaProvider.js
@@ -1,0 +1,288 @@
+const axios = require('axios');
+const { v4: uuidv4 } = require('uuid');
+
+class CodaProvider {
+  constructor(config = {}){
+    this.config = config;
+    this.http = null;
+    this.rowCache = new Map();
+  }
+
+  async init(){
+    this.http = axios.create({
+      baseURL: 'https://coda.io/apis/v1',
+      headers: this.config.apiToken ? {
+        Authorization: `Bearer ${this.config.apiToken}`,
+        'Content-Type': 'application/json'
+      } : {}
+    });
+    this.rowCache.clear();
+  }
+
+  async dispose(){
+    this.rowCache.clear();
+  }
+
+  _assertConfigured(){
+    const { apiToken, docId, tableId, showIdColumn, payloadColumn } = this.config || {};
+    if(!apiToken || !docId || !tableId || !showIdColumn || !payloadColumn){
+      throw new Error('Coda provider is not fully configured. Please supply API token, doc ID, table ID, show ID column, and payload column.');
+    }
+  }
+
+  async listShows(){
+    this._assertConfigured();
+    const rows = await this._fetchRows();
+    return rows.map(row=>this._rowToShow(row)).filter(Boolean);
+  }
+
+  async getShow(id){
+    this._assertConfigured();
+    if(this.rowCache.has(id)){
+      const rowId = this.rowCache.get(id);
+      const row = await this._getRowById(rowId);
+      return row ? this._rowToShow(row) : null;
+    }
+    const rows = await this._fetchRows();
+    const match = rows.find(r => this._getValue(r, this.config.showIdColumn) === id);
+    return match ? this._rowToShow(match) : null;
+  }
+
+  async createShow(input){
+    this._assertConfigured();
+    const now = Date.now();
+    const show = this._normalizeShow({
+      ...input,
+      id: input.id || uuidv4(),
+      createdAt: now,
+      updatedAt: now,
+      entries: Array.isArray(input.entries) ? input.entries : []
+    });
+    await this._upsertRow(show);
+    return show;
+  }
+
+  async updateShow(id, updates){
+    this._assertConfigured();
+    const existing = await this.getShow(id);
+    if(!existing){
+      return null;
+    }
+    const updated = this._normalizeShow({
+      ...existing,
+      ...updates,
+      updatedAt: Date.now()
+    });
+    await this._upsertRow(updated);
+    return updated;
+  }
+
+  async deleteShow(id){
+    this._assertConfigured();
+    if(!this.rowCache.has(id)){
+      await this.listShows();
+    }
+    const rowId = this.rowCache.get(id);
+    if(!rowId){
+      return;
+    }
+    await this.http.delete(`/docs/${this.config.docId}/tables/${this.config.tableId}/rows/${encodeURIComponent(rowId)}`);
+    this.rowCache.delete(id);
+  }
+
+  async addEntry(showId, entryInput){
+    this._assertConfigured();
+    const show = await this.getShow(showId);
+    if(!show){
+      return null;
+    }
+    const entry = this._normalizeEntry({
+      ...entryInput,
+      id: entryInput.id || uuidv4(),
+      ts: entryInput.ts || Date.now()
+    });
+    const idx = show.entries.findIndex(e=>e.id===entry.id);
+    if(idx >= 0){
+      show.entries[idx] = entry;
+    }else{
+      show.entries.push(entry);
+    }
+    show.updatedAt = Date.now();
+    await this._upsertRow(show);
+    return entry;
+  }
+
+  async updateEntry(showId, entryId, updates){
+    this._assertConfigured();
+    const show = await this.getShow(showId);
+    if(!show){
+      return null;
+    }
+    const idx = show.entries.findIndex(e=>e.id===entryId);
+    if(idx < 0){
+      return null;
+    }
+    const entry = this._normalizeEntry({
+      ...show.entries[idx],
+      ...updates
+    });
+    show.entries[idx] = entry;
+    show.updatedAt = Date.now();
+    await this._upsertRow(show);
+    return entry;
+  }
+
+  async deleteEntry(showId, entryId){
+    this._assertConfigured();
+    const show = await this.getShow(showId);
+    if(!show){
+      return null;
+    }
+    const idx = show.entries.findIndex(e=>e.id===entryId);
+    if(idx < 0){
+      return null;
+    }
+    show.entries.splice(idx,1);
+    show.updatedAt = Date.now();
+    await this._upsertRow(show);
+    return true;
+  }
+
+  async replaceShow(show){
+    this._assertConfigured();
+    const normalized = this._normalizeShow(show);
+    await this._upsertRow(normalized);
+    return normalized;
+  }
+
+  async _fetchRows(){
+    const rows = [];
+    let pageToken;
+    do {
+      const res = await this.http.get(`/docs/${this.config.docId}/tables/${this.config.tableId}/rows`, {
+        params: {
+          useColumnNames: true,
+          pageToken
+        }
+      });
+      const items = res.data?.items || [];
+      rows.push(...items);
+      pageToken = res.data?.nextPageToken;
+    } while(pageToken);
+    this.rowCache.clear();
+    rows.forEach(row => {
+      const showId = this._getValue(row, this.config.showIdColumn);
+      if(showId){
+        this.rowCache.set(showId, row.id);
+      }
+    });
+    return rows;
+  }
+
+  async _getRowById(rowId){
+    const res = await this.http.get(`/docs/${this.config.docId}/tables/${this.config.tableId}/rows/${encodeURIComponent(rowId)}`, {
+      params: { useColumnNames: true }
+    });
+    return res.data;
+  }
+
+  async _upsertRow(show){
+    const rowId = this.rowCache.get(show.id);
+    const payload = JSON.stringify(show);
+    if(rowId){
+      await this.http.put(`/docs/${this.config.docId}/tables/${this.config.tableId}/rows/${encodeURIComponent(rowId)}`, {
+        row: {
+          cells: [
+            { column: this.config.showIdColumn, value: show.id },
+            { column: this.config.payloadColumn, value: payload }
+          ]
+        }
+      });
+    }else{
+      await this.http.post(`/docs/${this.config.docId}/tables/${this.config.tableId}/rows`, {
+        rows: [
+          {
+            cells: [
+              { column: this.config.showIdColumn, value: show.id },
+              { column: this.config.payloadColumn, value: payload }
+            ]
+          }
+        ],
+        keyColumns: [this.config.showIdColumn]
+      });
+    }
+    await this._fetchRows();
+  }
+
+  _rowToShow(row){
+    try{
+      const rawPayload = this._getValue(row, this.config.payloadColumn);
+      const show = typeof rawPayload === 'string' ? JSON.parse(rawPayload) : rawPayload;
+      if(!show.id){
+        show.id = this._getValue(row, this.config.showIdColumn) || row.id;
+      }
+      show.entries = Array.isArray(show.entries) ? show.entries.map(e=>this._normalizeEntry(e)) : [];
+      show.createdAt = show.createdAt || Date.now();
+      show.updatedAt = show.updatedAt || Date.now();
+      if(show.id){
+        this.rowCache.set(show.id, row.id);
+      }
+      return show;
+    }catch(err){
+      console.error('Failed to parse Coda row', err);
+      return null;
+    }
+  }
+
+  _getValue(row, column){
+    if(!row || !row.values){
+      return undefined;
+    }
+    return row.values[column];
+  }
+
+  _normalizeShow(raw){
+    const createdAt = typeof raw.createdAt === 'number' ? raw.createdAt : Number(raw.createdAt);
+    const updatedAt = typeof raw.updatedAt === 'number' ? raw.updatedAt : Number(raw.updatedAt);
+    return {
+      id: raw.id,
+      date: raw.date || '',
+      time: raw.time || '',
+      label: raw.label || '',
+      crew: Array.isArray(raw.crew) ? raw.crew : [],
+      leadPilot: raw.leadPilot || '',
+      monkeyLead: raw.monkeyLead || '',
+      notes: raw.notes || '',
+      entries: Array.isArray(raw.entries) ? raw.entries.map(e=>this._normalizeEntry(e)) : [],
+      createdAt: Number.isFinite(createdAt) ? createdAt : Date.now(),
+      updatedAt: Number.isFinite(updatedAt) ? updatedAt : Date.now()
+    };
+  }
+
+  _normalizeEntry(raw){
+    const ts = typeof raw.ts === 'number' ? raw.ts : Number(raw.ts);
+    return {
+      id: raw.id || uuidv4(),
+      ts: Number.isFinite(ts) ? ts : Date.now(),
+      unitId: raw.unitId || '',
+      planned: raw.planned || '',
+      launched: raw.launched || '',
+      status: raw.status || '',
+      primaryIssue: raw.primaryIssue || '',
+      subIssue: raw.subIssue || '',
+      otherDetail: raw.otherDetail || '',
+      severity: raw.severity || '',
+      rootCause: raw.rootCause || '',
+      actions: Array.isArray(raw.actions) ? raw.actions : [],
+      operator: raw.operator || '',
+      batteryId: raw.batteryId || '',
+      delaySec: raw.delaySec === null || raw.delaySec === undefined || raw.delaySec === ''
+        ? null
+        : Number(raw.delaySec),
+      commandRx: raw.commandRx || '',
+      notes: raw.notes || ''
+    };
+  }
+}
+
+module.exports = CodaProvider;

--- a/server/storage/index.js
+++ b/server/storage/index.js
@@ -1,0 +1,35 @@
+const SqlProvider = require('./sqlProvider');
+const CodaProvider = require('./codaProvider');
+
+let providerInstance = null;
+let providerName = null;
+
+async function initProvider(config){
+  if(providerInstance && typeof providerInstance.dispose === 'function'){
+    await providerInstance.dispose();
+  }
+  providerName = config.provider === 'coda' ? 'coda' : 'sql';
+  const providerConfig = providerName === 'coda' ? config.coda : config.sql;
+  providerInstance = providerName === 'coda'
+    ? new CodaProvider(providerConfig)
+    : new SqlProvider(providerConfig);
+  await providerInstance.init();
+  return providerInstance;
+}
+
+function getProvider(){
+  if(!providerInstance){
+    throw new Error('Storage provider not initialized');
+  }
+  return providerInstance;
+}
+
+function getProviderName(){
+  return providerName;
+}
+
+module.exports = {
+  initProvider,
+  getProvider,
+  getProviderName
+};

--- a/server/storage/sqlProvider.js
+++ b/server/storage/sqlProvider.js
@@ -1,0 +1,191 @@
+const fs = require('fs');
+const path = require('path');
+const { open } = require('sqlite');
+const sqlite3 = require('sqlite3');
+const { v4: uuidv4 } = require('uuid');
+
+class SqlProvider {
+  constructor(config = {}){
+    this.config = config;
+    this.db = null;
+  }
+
+  async init(){
+    const filename = this.config.filename || path.join(process.cwd(), 'data', 'monkey-tracker.sqlite');
+    await fs.promises.mkdir(path.dirname(filename), {recursive: true});
+    this.db = await open({filename, driver: sqlite3.Database});
+    await this.db.exec(`
+      CREATE TABLE IF NOT EXISTS shows (
+        id TEXT PRIMARY KEY,
+        data TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+  }
+
+  async dispose(){
+    if(this.db){
+      await this.db.close();
+      this.db = null;
+    }
+  }
+
+  async listShows(){
+    const rows = await this.db.all('SELECT data FROM shows ORDER BY updated_at DESC');
+    return rows.map(r=>JSON.parse(r.data));
+  }
+
+  async getShow(id){
+    const row = await this.db.get('SELECT data FROM shows WHERE id = ?', id);
+    return row ? JSON.parse(row.data) : null;
+  }
+
+  async createShow(input){
+    const now = Date.now();
+    const show = this._normalizeShow({
+      ...input,
+      id: input.id || uuidv4(),
+      createdAt: now,
+      updatedAt: now,
+      entries: Array.isArray(input.entries) ? input.entries : []
+    });
+    await this._persist(show);
+    return show;
+  }
+
+  async updateShow(id, updates){
+    const existing = await this.getShow(id);
+    if(!existing){
+      return null;
+    }
+    const updated = this._normalizeShow({
+      ...existing,
+      ...updates,
+      updatedAt: Date.now()
+    });
+    await this._persist(updated);
+    return updated;
+  }
+
+  async deleteShow(id){
+    await this.db.run('DELETE FROM shows WHERE id = ?', id);
+  }
+
+  async addEntry(showId, entryInput){
+    const show = await this.getShow(showId);
+    if(!show){
+      return null;
+    }
+    const entry = this._normalizeEntry({
+      ...entryInput,
+      id: entryInput.id || uuidv4(),
+      ts: entryInput.ts || Date.now()
+    });
+    const idx = show.entries.findIndex(e=>e.id===entry.id);
+    if(idx >= 0){
+      show.entries[idx] = entry;
+    }else{
+      show.entries.push(entry);
+    }
+    show.updatedAt = Date.now();
+    await this._persist(show);
+    return entry;
+  }
+
+  async updateEntry(showId, entryId, updates){
+    const show = await this.getShow(showId);
+    if(!show){
+      return null;
+    }
+    const idx = show.entries.findIndex(e=>e.id===entryId);
+    if(idx < 0){
+      return null;
+    }
+    const entry = this._normalizeEntry({
+      ...show.entries[idx],
+      ...updates
+    });
+    show.entries[idx] = entry;
+    show.updatedAt = Date.now();
+    await this._persist(show);
+    return entry;
+  }
+
+  async deleteEntry(showId, entryId){
+    const show = await this.getShow(showId);
+    if(!show){
+      return null;
+    }
+    const idx = show.entries.findIndex(e=>e.id===entryId);
+    if(idx < 0){
+      return null;
+    }
+    show.entries.splice(idx, 1);
+    show.updatedAt = Date.now();
+    await this._persist(show);
+    return true;
+  }
+
+  async replaceShow(show){
+    const normalized = this._normalizeShow(show);
+    await this._persist(normalized);
+    return normalized;
+  }
+
+  _normalizeShow(raw){
+    const createdAt = typeof raw.createdAt === 'number' ? raw.createdAt : Number(raw.createdAt);
+    const updatedAt = typeof raw.updatedAt === 'number' ? raw.updatedAt : Number(raw.updatedAt);
+    return {
+      id: raw.id,
+      date: raw.date || '',
+      time: raw.time || '',
+      label: raw.label || '',
+      crew: Array.isArray(raw.crew) ? raw.crew : [],
+      leadPilot: raw.leadPilot || '',
+      monkeyLead: raw.monkeyLead || '',
+      notes: raw.notes || '',
+      entries: Array.isArray(raw.entries) ? raw.entries.map(e=>this._normalizeEntry(e)) : [],
+      createdAt: Number.isFinite(createdAt) ? createdAt : Date.now(),
+      updatedAt: Number.isFinite(updatedAt) ? updatedAt : Date.now()
+    };
+  }
+
+  _normalizeEntry(raw){
+    const ts = typeof raw.ts === 'number' ? raw.ts : Number(raw.ts);
+    return {
+      id: raw.id || uuidv4(),
+      ts: Number.isFinite(ts) ? ts : Date.now(),
+      unitId: raw.unitId || '',
+      planned: raw.planned || '',
+      launched: raw.launched || '',
+      status: raw.status || '',
+      primaryIssue: raw.primaryIssue || '',
+      subIssue: raw.subIssue || '',
+      otherDetail: raw.otherDetail || '',
+      severity: raw.severity || '',
+      rootCause: raw.rootCause || '',
+      actions: Array.isArray(raw.actions) ? raw.actions : [],
+      operator: raw.operator || '',
+      batteryId: raw.batteryId || '',
+      delaySec: raw.delaySec === null || raw.delaySec === undefined || raw.delaySec === ''
+        ? null
+        : Number(raw.delaySec),
+      commandRx: raw.commandRx || '',
+      notes: raw.notes || ''
+    };
+  }
+
+  async _persist(show){
+    const payload = JSON.stringify(show);
+    const updated = new Date(show.updatedAt || Date.now()).toISOString();
+    await this.db.run(
+      `INSERT INTO shows (id, data, updated_at) VALUES (?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at`,
+      show.id,
+      payload,
+      updated
+    );
+  }
+}
+
+module.exports = SqlProvider;


### PR DESCRIPTION
## Summary
- bind the Express server to the configurable 10.241.211.120 host/port defaults with a safe fallback and expose the active binding through the config and health endpoints
- add a LAN connection banner, provider badge, and manual refresh control to the dashboard with supporting styles and client logic
- document the direct `node server/index.js` startup flow, LAN options, and update scripts to avoid npm-based startup

## Testing
- node server/index.js
- curl -s http://127.0.0.1:3000/api/health

------
https://chatgpt.com/codex/tasks/task_e_68d15ee16f70832ab1778be71df2b470