### PR TITLE
Normalize provider badge classes

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1096,7 +1096,9 @@ function setLanAddress(){
 
 function setProviderBadge(label){
   if(!providerBadge){ return; }
-  providerBadge.classList.remove('provider-coda');
+  Array.from(providerBadge.classList)
+    .filter(cls => cls.startsWith('provider-'))
+    .forEach(cls => providerBadge.classList.remove(cls));
   providerBadge.classList.add('provider-sql');
   const text = label || 'SQL.js storage v2';
   providerBadge.textContent = text;


### PR DESCRIPTION
## Summary
- ensure the provider badge drops any legacy provider-* classes before applying the sql.js style so no stale coda classes linger

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d22bc8c9fc832a91cea09c0dbc5ee7