### PR TITLE
Implement roster management and enforce show constraints

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,8 +10,14 @@
   <div class="topbar" role="banner">
     <div class="toolbar">
       <div class="row">
+        <button id="roleHome" class="btn ghost" type="button">← Choose role</button>
+        <div class="grow"></div>
+        <button id="refreshShows" type="button" class="btn ghost">Refresh data</button>
         <button id="configBtn" class="btn icon-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings">⚙️</button>
+      </div>
+      <div class="row">
         <h1><span id="appTitle">Drone</span> Tracker</h1>
+        <span id="viewBadge" class="badge view-badge">Lead workspace</span>
       </div>
     </div>
   </div>
@@ -56,6 +62,38 @@
         <textarea id="webhookHeaders" placeholder="One per line, e.g., Authorization: Bearer token"></textarea>
         <div id="webhookPreview" class="webhook-preview" aria-live="polite"></div>
       </fieldset>
+      <fieldset id="exportFields" class="col-12 provider-fields">
+        <legend>Lead exports</legend>
+        <p class="help">Download the currently selected show for offline analysis.</p>
+        <div class="row" style="justify-content:flex-start; gap:10px;">
+          <button type="button" id="leadExportCsv" class="btn ghost">Export CSV</button>
+          <button type="button" id="leadExportJson" class="btn ghost">Export JSON</button>
+        </div>
+      </fieldset>
+      <fieldset id="rosterFields" class="col-12 provider-fields">
+        <legend>Pilot &amp; crew roster</legend>
+        <p class="help">Names added here are available in both Lead and Pilot workspaces.</p>
+        <div class="grid roster-grid">
+          <div class="col-6">
+            <label for="newPilotName">Add pilot</label>
+            <div class="roster-input">
+              <input id="newPilotName" type="text" placeholder="Pilot name" autocomplete="off" />
+              <button type="button" id="addPilotBtn" class="btn ghost">Add</button>
+            </div>
+            <p class="help">Pilots can be assigned to shows and entries.</p>
+            <ul id="pilotList" class="roster-list" aria-live="polite"></ul>
+          </div>
+          <div class="col-6">
+            <label for="newCrewName">Add crew member</label>
+            <div class="roster-input">
+              <input id="newCrewName" type="text" placeholder="Crew name" autocomplete="off" />
+              <button type="button" id="addCrewBtn" class="btn ghost">Add</button>
+            </div>
+            <p class="help">Remove names using the × button next to each entry.</p>
+            <ul id="crewList" class="roster-list" aria-live="polite"></ul>
+          </div>
+        </div>
+      </fieldset>
       <div class="col-12 row" style="justify-content: flex-end; gap: 10px;">
         <button type="button" id="cancelConfig" class="btn ghost">Cancel</button>
         <button type="submit" class="btn primary">Save settings</button>
@@ -67,30 +105,17 @@
   </div>
 
   <div class="container" role="main">
-    <section class="panel info-panel" aria-labelledby="welcomeTitle">
-      <div class="info-grid">
-        <div class="info-copy">
-          <h2 id="welcomeTitle">Live show dashboard</h2>
-          <p class="lead">Capture each run in real time. Start a new show, log entries, and keep everyone aligned.</p>
-          <ul class="quick-hints" role="list">
-            <li><strong>New Show</strong> creates a fresh record with default crew and units.</li>
-            <li><strong>Duplicate Current Show</strong> reuses the crew roster for the next run.</li>
-            <li>Adjust SQL.js storage settings and optional webhook delivery from the ⚙️ settings menu.</li>
-          </ul>
-        </div>
-        <div class="lan-status" aria-live="polite">
-          <div id="connectionStatus" class="connection-status is-pending">Checking server…</div>
-          <div class="lan-controls">
-            <span id="providerBadge" class="badge provider-sql" aria-label="Active storage provider">SQL.js storage v2</span>
-            <span id="webhookBadge" class="badge badge-webhook-off" aria-label="Webhook status">Webhook disabled</span>
-            <button id="refreshShows" type="button" class="btn ghost">Refresh data</button>
-          </div>
-          <div class="lan-target">LAN URL: <code id="lanAddress">http://10.241.211.120:3000</code></div>
-        </div>
+    <section id="landingView" class="panel landing-panel view-landing-only" aria-labelledby="landingTitle">
+      <h2 id="landingTitle">Choose workspace</h2>
+      <p class="lead">Select the role you need for this session.</p>
+      <div class="role-options">
+        <button id="chooseLead" type="button" class="btn primary role-btn">Lead</button>
+        <button id="choosePilot" type="button" class="btn role-btn">Pilot</button>
       </div>
+      <p class="help">Lead sets up shows and manages exports. Pilot logs entries against those shows.</p>
     </section>
 
-    <section class="panel" aria-labelledby="showHeaderTitle">
+    <section class="panel view-lead-only" aria-labelledby="showHeaderTitle">
       <h2 id="showHeaderTitle">Show header</h2>
       <div class="grid">
         <div class="col-3">
@@ -106,8 +131,9 @@
           <input id="showLabel" type="text" placeholder="e.g., 7pm Main" />
         </div>
         <div class="col-6">
-          <label>Crew on duty <span class="help">(press Enter to add name)</span></label>
-          <div id="crewInput" class="chip-input" aria-label="Crew on duty input"></div>
+          <label for="crewSelect">Crew on duty</label>
+          <select id="crewSelect" multiple size="5" aria-label="Crew on duty"></select>
+          <p class="help">Manage crew roster in Settings.</p>
         </div>
         <div class="col-3">
           <label for="leadPilot">Lead Pilot</label>
@@ -124,9 +150,14 @@
       </div>
     </section>
 
-    <section class="panel" aria-labelledby="entryTitle">
+    <section class="panel view-pilot-only" aria-labelledby="entryTitle">
       <h2 id="entryTitle">Entry form</h2>
       <div class="grid" id="entryForm">
+        <div class="col-12">
+          <label for="entryShowSelect">Assign to show</label>
+          <select id="entryShowSelect"></select>
+          <div id="pilotShowSummary" class="help">Select a show to start logging entries.</div>
+        </div>
         <div class="col-2">
           <label for="unitId"><span id="unitLabel">Monkey</span> ID</label>
           <select id="unitId"></select>
@@ -201,6 +232,7 @@
         <div class="col-3">
           <label for="operator">Operator</label>
           <select id="operator"></select>
+          <div class="error" id="errOperator" hidden>Required</div>
         </div>
         <div class="col-3">
           <label for="batteryId">Battery ID</label>
@@ -226,16 +258,14 @@
       </div>
     </section>
 
-    <section id="groups"></section>
+    <section id="groups" class="view-lead-only"></section>
   </div>
 
   <div class="sticky-footer" role="contentinfo">
     <div class="footer-grid">
-      <button id="newShow" class="btn span-3">New Show</button>
-      <button id="dupShow" class="btn span-3">Duplicate Current Show</button>
-      <button id="addLine" class="btn primary span-3">Add line</button>
-      <button id="exportCsv" class="btn ghost span-3">Export CSV</button>
-      <button id="exportJson" class="btn ghost span-3">Export JSON</button>
+      <button id="newShow" class="btn span-4 view-lead-only">New Show</button>
+      <button id="dupShow" class="btn span-4 view-lead-only">Duplicate Current Show</button>
+      <button id="addLine" class="btn primary span-4 view-pilot-only">Add line</button>
     </div>
   </div>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -40,6 +40,27 @@ a{color:var(--primary);text-decoration:none}
   margin:0 auto;
   padding:14px 16px 120px;
 }
+#roleHome{display:none}
+body.view-lead #roleHome,
+body.view-pilot #roleHome{display:inline-flex}
+#viewBadge{display:none}
+body.view-lead #viewBadge,
+body.view-pilot #viewBadge{display:inline-flex}
+body.view-landing #refreshShows{display:none}
+body.view-landing .sticky-footer{display:none}
+.view-lead-only,
+.view-pilot-only,
+.view-landing-only{display:none !important}
+body.view-lead .view-lead-only{display:block !important}
+body.view-pilot .view-pilot-only{display:block !important}
+body.view-landing .view-landing-only{display:block !important}
+#landingView{display:none;text-align:center;padding:38px 20px}
+body.view-landing #landingView{display:block}
+.role-options{display:flex;gap:16px;justify-content:center;flex-wrap:wrap;margin-top:22px}
+.role-btn{min-width:160px;font-size:18px;padding:18px 26px}
+.view-badge{background:rgba(74,163,255,.18);color:#aed4ff;border-color:rgba(74,163,255,.45)}
+.view-badge-pilot{background:rgba(31,198,122,.22);color:#bff7d9;border-color:rgba(31,198,122,.5)}
+#pilotShowSummary{margin-top:8px;padding:10px 12px;border:1px dashed var(--border);border-radius:10px;background:rgba(255,255,255,.03);color:var(--text-dim);font-size:13px;text-align:left}
 .topbar{
   position:sticky;top:0;z-index:50;
   background:linear-gradient(to bottom, rgba(14,15,18,.95), rgba(14,15,18,.85) 60%, transparent);
@@ -123,7 +144,7 @@ input:disabled, select:disabled, textarea:disabled{opacity:.55; cursor:not-allow
   background-clip: padding-box;
 }
 textarea{min-height:84px; resize:vertical}
-input:focus, select:focus, textarea:focus, .btn:focus-visible, .chip-input input:focus{
+input:focus, select:focus, textarea:focus, .btn:focus-visible{
   border-color:var(--focus);
   box-shadow:0 0 0 3px rgba(154, 210, 255, 0.95);
 }
@@ -168,21 +189,19 @@ input:focus, select:focus, textarea:focus, .btn:focus-visible, .chip-input input
   .footer-grid .span-2,.footer-grid .span-3,.footer-grid .span-4{grid-column:span 12}
 }
 
-.chips{display:flex;gap:8px;flex-wrap:wrap}
-.chip{
-  background:var(--chip); border:1px solid var(--border);
-  border-radius:999px; padding:8px 12px; min-height:var(--tap-min);
-  display:inline-flex; align-items:center; gap:8px; color:var(--text);
-}
-.chip .x{background:transparent; border:none; color:var(--text-dim); cursor:pointer; font-size:18px; line-height:1; padding:0; width:24px; height:24px}
-.chip-input{
-  display:flex; align-items:center; flex-wrap:wrap; gap:8px; background:var(--input); border:1px solid var(--border);
-  border-radius:10px; padding:8px; min-height:var(--tap-min);
-}
-.chip-input input{
-  border:none;background:transparent; min-height:32px; padding:8px;
-  flex:1; outline:none;
-}
+.roster-grid{align-items:flex-start}
+.roster-input{display:flex; gap:10px; align-items:center}
+.roster-input input{flex:1}
+.roster-list{list-style:none; margin:8px 0 0; padding:0; border:1px solid var(--border); border-radius:12px; background:var(--input);
+  max-height:200px; overflow-y:auto;}
+.roster-list li{display:flex; align-items:center; justify-content:space-between; gap:12px; padding:8px 12px; border-bottom:1px solid rgba(255,255,255,.06);}
+.roster-list li:last-child{border-bottom:none}
+.roster-list li span{flex:1; word-break:break-word;}
+.roster-list .empty{padding:14px 12px; text-align:center; color:var(--text-dim); font-style:italic;}
+.roster-remove{background:transparent; border:1px solid transparent; color:var(--text-dim); cursor:pointer; font-size:18px; line-height:1;
+  width:30px; height:30px; display:grid; place-items:center; border-radius:50%;}
+.roster-remove:hover{color:var(--danger); border-color:rgba(255,93,93,.4);}
+select[multiple]{min-height:160px; padding-top:10px; padding-bottom:10px;}
 
 .pills{display:flex; gap:8px; flex-wrap:wrap}
 .pill{

--- a/server/storage/sqlProvider.js
+++ b/server/storage/sqlProvider.js
@@ -3,6 +3,8 @@ const path = require('path');
 const initSqlJs = require('sql.js');
 const { v4: uuidv4 } = require('uuid');
 
+const DEFAULT_ROSTER = ['Alex','Nick','John Henery','James','Robert','Nazar'];
+
 class SqlProvider {
   constructor(config = {}){
     this.config = config;
@@ -25,12 +27,19 @@ class SqlProvider {
       return;
     }
 
+    let created = false;
     if(await this._fileExists(this.filename)){
       const content = await fs.promises.readFile(this.filename);
       this.db = new this.SQL.Database(content);
     }else{
       this.db = new this.SQL.Database();
-      this._createSchema();
+      created = true;
+    }
+
+    this._createSchema();
+    await this._seedDefaultRoster();
+
+    if(created){
       await this._persistDatabase();
     }
   }
@@ -61,6 +70,7 @@ class SqlProvider {
       updatedAt: now,
       entries: Array.isArray(input.entries) ? input.entries : []
     });
+    await this._enforceDailyShowLimit(show.date, show.id);
     await this._persist(show);
     return show;
   }
@@ -75,6 +85,7 @@ class SqlProvider {
       ...updates,
       updatedAt: Date.now()
     });
+    await this._enforceDailyShowLimit(updated.date, updated.id);
     await this._persist(updated);
     return updated;
   }
@@ -88,6 +99,21 @@ class SqlProvider {
     const show = await this.getShow(showId);
     if(!show){
       return null;
+    }
+    const operatorName = this._normalizeRosterName(entryInput.operator);
+    if(!operatorName){
+      throw this._validationError('Pilot is required for an entry');
+    }
+    const roster = await this.listPilots();
+    const known = roster.some(pilot => pilot.name.toLowerCase() === operatorName.toLowerCase());
+    if(!known){
+      throw this._validationError('Pilot must exist in the roster');
+    }
+    const duplicate = (show.entries || []).some(entry =>
+      entry.operator && entry.operator.toLowerCase() === operatorName.toLowerCase()
+    );
+    if(duplicate){
+      throw this._validationError('Pilot already has an entry for this show');
     }
     const entry = this._normalizeEntry({
       ...entryInput,
@@ -118,6 +144,23 @@ class SqlProvider {
       ...show.entries[idx],
       ...updates
     });
+    const operatorName = this._normalizeRosterName(entry.operator);
+    if(!operatorName){
+      throw this._validationError('Pilot is required for an entry');
+    }
+    const roster = await this.listPilots();
+    const known = roster.some(pilot => pilot.name.toLowerCase() === operatorName.toLowerCase());
+    if(!known){
+      throw this._validationError('Pilot must exist in the roster');
+    }
+    const duplicate = show.entries.some(existingEntry =>
+      existingEntry.id !== entry.id &&
+      existingEntry.operator &&
+      existingEntry.operator.toLowerCase() === operatorName.toLowerCase()
+    );
+    if(duplicate){
+      throw this._validationError('Pilot already has an entry for this show');
+    }
     show.entries[idx] = entry;
     show.updatedAt = Date.now();
     await this._persist(show);
@@ -153,9 +196,9 @@ class SqlProvider {
       date: raw.date || '',
       time: raw.time || '',
       label: raw.label || '',
-      crew: Array.isArray(raw.crew) ? raw.crew : [],
-      leadPilot: raw.leadPilot || '',
-      monkeyLead: raw.monkeyLead || '',
+      crew: Array.isArray(raw.crew) ? raw.crew.map(name => this._normalizeRosterName(name)).filter(Boolean) : [],
+      leadPilot: this._normalizeRosterName(raw.leadPilot),
+      monkeyLead: this._normalizeRosterName(raw.monkeyLead),
       notes: raw.notes || '',
       entries: Array.isArray(raw.entries) ? raw.entries.map(e => this._normalizeEntry(e)) : [],
       createdAt: Number.isFinite(createdAt) ? createdAt : Date.now(),
@@ -178,7 +221,7 @@ class SqlProvider {
       severity: raw.severity || '',
       rootCause: raw.rootCause || '',
       actions: Array.isArray(raw.actions) ? raw.actions : [],
-      operator: raw.operator || '',
+      operator: this._normalizeRosterName(raw.operator),
       batteryId: raw.batteryId || '',
       delaySec: raw.delaySec === null || raw.delaySec === undefined || raw.delaySec === ''
         ? null
@@ -194,8 +237,125 @@ class SqlProvider {
         id TEXT PRIMARY KEY,
         data TEXT NOT NULL,
         updated_at TEXT NOT NULL
-      )
+      );
+      CREATE TABLE IF NOT EXISTS pilots (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE COLLATE NOCASE,
+        created_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS crew_members (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE COLLATE NOCASE,
+        created_at TEXT NOT NULL
+      );
     `);
+  }
+
+  async listPilots(){
+    const rows = this._select('SELECT id, name FROM pilots ORDER BY name COLLATE NOCASE ASC');
+    return rows.map(row => ({id: row.id, name: row.name}));
+  }
+
+  async createPilot(input){
+    const name = this._normalizeRosterName(input?.name || input);
+    if(!name){
+      throw this._validationError('Pilot name is required');
+    }
+    const existing = this._selectOne('SELECT id FROM pilots WHERE lower(name) = lower(?)', [name]);
+    if(existing){
+      throw this._validationError('Pilot already exists');
+    }
+    const pilot = {id: uuidv4(), name};
+    const now = new Date().toISOString();
+    this._run('INSERT INTO pilots (id, name, created_at) VALUES (?, ?, ?)', [pilot.id, pilot.name, now]);
+    await this._persistDatabase();
+    return pilot;
+  }
+
+  async deletePilot(id){
+    if(!id){
+      return false;
+    }
+    this._run('DELETE FROM pilots WHERE id = ?', [id]);
+    await this._persistDatabase();
+    return true;
+  }
+
+  async listCrew(){
+    const rows = this._select('SELECT id, name FROM crew_members ORDER BY name COLLATE NOCASE ASC');
+    return rows.map(row => ({id: row.id, name: row.name}));
+  }
+
+  async createCrewMember(input){
+    const name = this._normalizeRosterName(input?.name || input);
+    if(!name){
+      throw this._validationError('Crew member name is required');
+    }
+    const existing = this._selectOne('SELECT id FROM crew_members WHERE lower(name) = lower(?)', [name]);
+    if(existing){
+      throw this._validationError('Crew member already exists');
+    }
+    const crew = {id: uuidv4(), name};
+    const now = new Date().toISOString();
+    this._run('INSERT INTO crew_members (id, name, created_at) VALUES (?, ?, ?)', [crew.id, crew.name, now]);
+    await this._persistDatabase();
+    return crew;
+  }
+
+  async deleteCrewMember(id){
+    if(!id){
+      return false;
+    }
+    this._run('DELETE FROM crew_members WHERE id = ?', [id]);
+    await this._persistDatabase();
+    return true;
+  }
+
+  async _seedDefaultRoster(){
+    const pilotCount = this._selectOne('SELECT COUNT(1) as count FROM pilots');
+    const crewCount = this._selectOne('SELECT COUNT(1) as count FROM crew_members');
+    const now = new Date().toISOString();
+    if(!pilotCount || pilotCount.count === 0){
+      DEFAULT_ROSTER.forEach(name =>{
+        const normalized = this._normalizeRosterName(name);
+        if(normalized){
+          this._run('INSERT INTO pilots (id, name, created_at) VALUES (?, ?, ?)', [uuidv4(), normalized, now]);
+        }
+      });
+    }
+    if(!crewCount || crewCount.count === 0){
+      DEFAULT_ROSTER.forEach(name =>{
+        const normalized = this._normalizeRosterName(name);
+        if(normalized){
+          this._run('INSERT INTO crew_members (id, name, created_at) VALUES (?, ?, ?)', [uuidv4(), normalized, now]);
+        }
+      });
+    }
+    await this._persistDatabase();
+  }
+
+  async _enforceDailyShowLimit(date, currentId){
+    if(!date){
+      return;
+    }
+    const shows = await this.listShows();
+    const count = shows.filter(show => show.date === date && show.id !== currentId).length;
+    if(count >= 5){
+      throw this._validationError('Daily show limit reached for this date');
+    }
+  }
+
+  _normalizeRosterName(value){
+    if(typeof value !== 'string'){
+      return '';
+    }
+    return value.trim();
+  }
+
+  _validationError(message){
+    const err = new Error(message);
+    err.statusCode = 400;
+    return err;
   }
 
   async _persist(show){


### PR DESCRIPTION
## Summary
- persist pilot and crew rosters in storage with new API endpoints while enforcing a five-show-per-day cap and preventing duplicate pilots per show
- connect the lead and pilot UIs to the shared roster, adding crew multi-selects, roster validation, and settings controls for managing names
- restyle the configuration dialog to host roster lists and tidy the entry form validation for required operators

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2352716c0832a8bb75775eade9286