### PR TITLE
Refine show layout and monkey lead management

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,9 @@
         <button id="roleHome" class="btn ghost" type="button">← Choose role</button>
         <div class="grow"></div>
         <button id="refreshShows" type="button" class="btn ghost">Refresh data</button>
-        <button id="configBtn" class="btn icon-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings">⚙️</button>
+        <button id="configBtn" class="btn icon-btn hamburger" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings" aria-label="Open settings menu">
+          ☰
+        </button>
       </div>
       <div class="row">
         <h1><span id="appTitle">Drone</span> Tracker</h1>
@@ -62,6 +64,16 @@
         <textarea id="webhookHeaders" placeholder="One per line, e.g., Authorization: Bearer token"></textarea>
         <div id="webhookPreview" class="webhook-preview" aria-live="polite"></div>
       </fieldset>
+      <fieldset id="staffFields" class="col-12 provider-fields">
+        <legend>Pilots &amp; crew</legend>
+        <p class="help">Add one name per line. These lists feed the Lead and Pilot workspaces.</p>
+        <label for="pilotList">Pilots</label>
+        <textarea id="pilotList" class="list-input" placeholder="e.g., Alex"></textarea>
+        <label for="crewList">Crew</label>
+        <textarea id="crewList" class="list-input" placeholder="e.g., Jamie"></textarea>
+        <label for="monkeyLeadList">Monkey leads</label>
+        <textarea id="monkeyLeadList" class="list-input" placeholder="e.g., Nazar"></textarea>
+      </fieldset>
       <fieldset id="exportFields" class="col-12 provider-fields">
         <legend>Lead exports</legend>
         <p class="help">Download the currently selected show for offline analysis.</p>
@@ -92,7 +104,10 @@
     </section>
 
     <section class="panel view-lead-only" aria-labelledby="showHeaderTitle">
-      <h2 id="showHeaderTitle">Show header</h2>
+      <div class="panel-header">
+        <h2 id="showHeaderTitle">Show header</h2>
+        <button id="newShow" class="btn primary" type="button">Add show</button>
+      </div>
       <div class="grid">
         <div class="col-3">
           <label for="showDate">Date</label>
@@ -107,8 +122,9 @@
           <input id="showLabel" type="text" placeholder="e.g., 7pm Main" />
         </div>
         <div class="col-6">
-          <label>Crew on duty <span class="help">(press Enter to add name)</span></label>
-          <div id="crewInput" class="chip-input" aria-label="Crew on duty input"></div>
+          <label for="showCrew">Crew on duty</label>
+          <select id="showCrew" multiple></select>
+          <p class="help">Hold Ctrl (Cmd on Mac) or Shift to select multiple crew members.</p>
         </div>
         <div class="col-3">
           <label for="leadPilot">Lead Pilot</label>
@@ -207,6 +223,7 @@
         <div class="col-3">
           <label for="operator">Operator</label>
           <select id="operator"></select>
+          <div class="error" id="errOperator" hidden>Required</div>
         </div>
         <div class="col-3">
           <label for="batteryId">Battery ID</label>
@@ -229,18 +246,13 @@
           <label for="entryNotes">Notes</label>
           <input id="entryNotes" type="text" placeholder="Short note" />
         </div>
+        <div class="col-12 entry-actions">
+          <button id="addLine" class="btn primary" type="button">Add line</button>
+        </div>
       </div>
     </section>
 
     <section id="groups" class="view-lead-only"></section>
-  </div>
-
-  <div class="sticky-footer" role="contentinfo">
-    <div class="footer-grid">
-      <button id="newShow" class="btn span-4 view-lead-only">New Show</button>
-      <button id="dupShow" class="btn span-4 view-lead-only">Duplicate Current Show</button>
-      <button id="addLine" class="btn primary span-4 view-pilot-only">Add line</button>
-    </div>
   </div>
 
   <div id="editModal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="editTitle">

--- a/public/styles.css
+++ b/public/styles.css
@@ -38,7 +38,7 @@ a{color:var(--primary);text-decoration:none}
 .container{
   max-width:1100px;
   margin:0 auto;
-  padding:14px 16px 120px;
+  padding:14px 16px 40px;
 }
 #roleHome{display:none}
 body.view-lead #roleHome,
@@ -47,7 +47,6 @@ body.view-pilot #roleHome{display:inline-flex}
 body.view-lead #viewBadge,
 body.view-pilot #viewBadge{display:inline-flex}
 body.view-landing #refreshShows{display:none}
-body.view-landing .sticky-footer{display:none}
 .view-lead-only,
 .view-pilot-only,
 .view-landing-only{display:none !important}
@@ -144,6 +143,14 @@ input:disabled, select:disabled, textarea:disabled{opacity:.55; cursor:not-allow
   background-clip: padding-box;
 }
 textarea{min-height:84px; resize:vertical}
+select[multiple]{
+  min-height:160px;
+}
+.list-input{
+  min-height:140px;
+  font-size:14px;
+  line-height:1.4;
+}
 input:focus, select:focus, textarea:focus, .btn:focus-visible, .chip-input input:focus{
   border-color:var(--focus);
   box-shadow:0 0 0 3px rgba(154, 210, 255, 0.95);
@@ -166,28 +173,12 @@ input:focus, select:focus, textarea:focus, .btn:focus-visible, .chip-input input
 .btn.primary{background:var(--primary); border-color:var(--primary-2); color:#041423}
 .btn.ghost{background:transparent}
 .btn.icon-btn{width:var(--tap-min); height:var(--tap-min); display:inline-grid; place-items:center; border-radius:12px;}
-.sticky-footer{
-  position:fixed; inset:auto 0 0 0; z-index:60;
-  background:linear-gradient(to top, rgba(22,24,29,.98), rgba(25, 30, 41, 0.96) 60%, rgba(29, 34, 47, 0.92));
-  backdrop-filter:saturate(1.2) blur(8px);
-  padding:10px 16px calc(16px + env(safe-area-inset-bottom));
-  border-top:1px solid var(--border);
-}
-.footer-grid{
-  display:grid; gap:10px;
-  grid-template-columns: repeat(12, 1fr);
-  max-width:1100px;margin:0 auto;
-}
-.footer-grid .btn{min-width:100%}
-.footer-grid .span-2{grid-column:span 2}
-.footer-grid .span-3{grid-column:span 3}
-.footer-grid .span-4{grid-column:span 4}
-@media (max-width:1100px){
-  .footer-grid .span-2,.footer-grid .span-3,.footer-grid .span-4{grid-column:span 6}
-}
-@media (max-width:520px){
-  .footer-grid .span-2,.footer-grid .span-3,.footer-grid .span-4{grid-column:span 12}
-}
+.btn.icon-btn.hamburger{font-size:22px; line-height:1;}
+.panel-header{display:flex; align-items:center; justify-content:space-between; gap:14px; margin-bottom:12px; flex-wrap:wrap}
+.panel-header h2{flex:1 1 auto; min-width:200px}
+.panel-header .btn{flex:0 0 auto}
+.entry-actions{display:flex; justify-content:flex-end; margin-top:4px}
+.entry-actions .btn{min-width:160px}
 
 .chips{display:flex;gap:8px;flex-wrap:wrap}
 .chip{
@@ -227,7 +218,9 @@ details.group > summary{
 }
 details.group[open] > summary{border-bottom:1px solid var(--border)}
 summary::-webkit-details-marker{display:none}
-.group-title{font-weight:800}
+.group-summary{display:flex; align-items:center; justify-content:space-between; gap:12px; width:100%}
+.group-summary-main{font-weight:800; flex:1; min-width:0}
+.group-summary-actions{display:flex; align-items:center; gap:10px}
 .metrics{display:flex;gap:10px;flex-wrap:wrap;padding:10px 14px;background:#12141a}
 .metric{
   background:var(--muted); border:1px solid var(--border); border-radius:12px; padding:8px 10px; font-size:13px; color:var(--text-dim)
@@ -262,7 +255,7 @@ summary::-webkit-details-marker{display:none}
 .modal-backdrop.open{display:flex}
 
 .toast{
-  position:fixed; left:50%; bottom:92px; transform:translateX(-50%);
+  position:fixed; left:50%; bottom:32px; transform:translateX(-50%);
   background:#0f131a; color:var(--text); border:1px solid var(--border); border-radius:999px; padding:12px 16px; z-index:100;
   box-shadow:var(--shadow); display:none
 }

--- a/server/index.js
+++ b/server/index.js
@@ -60,6 +60,18 @@ async function bootstrap(){
     res.json(config);
   }));
 
+  app.get('/api/staff', asyncHandler(async (req, res)=>{
+    const provider = getProvider();
+    const staff = await provider.getStaff();
+    res.json(staff);
+  }));
+
+  app.put('/api/staff', asyncHandler(async (req, res)=>{
+    const provider = getProvider();
+    const staff = await provider.replaceStaff(req.body || {});
+    res.json(staff);
+  }));
+
   app.get('/api/shows', asyncHandler(async (req, res)=>{
     const provider = getProvider();
     const shows = await provider.listShows();
@@ -144,7 +156,14 @@ async function bootstrap(){
 
   app.use((err, req, res, next)=>{ // eslint-disable-line no-unused-vars
     console.error(err);
-    res.status(500).json({error: 'Internal server error', detail: err.message});
+    const status = Number.isInteger(err.status) ? err.status : 500;
+    const payload = {
+      error: status === 500 ? 'Internal server error' : (err.message || 'Request failed')
+    };
+    if(status === 500 && err.message){
+      payload.detail = err.message;
+    }
+    res.status(status).json(payload);
   });
 
   function handleListenError(err){


### PR DESCRIPTION
## Summary
- move show creation controls into the lead header, drop the sticky footer, and surface per-show duplicate actions from an inline menu
- switch the settings icon to a right-aligned hamburger trigger and reposition the pilot add-line control within the entry form
- create a dedicated monkey lead roster in the database with settings management and independent lead dropdown population

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d24f175e4c832a98333bce7e644550