### PR TITLE
Revamp show controls and add monkey lead roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project exposes the **Drone Tracker** interface as a full web application b
 - Full-featured front-end built with HTML and CSS that retains the original look-and-feel and now surfaces a LAN connection dashboard for quick status checks.
 - Express.js backend API that manages shows, entries, and configuration.
 - SQL.js storage provider (v2) implemented with `sql.js` so no native builds are required. The server creates the database file if it does not exist.
-- Configurable application settings from the in-app settings panel (unit label, SQL.js database file, webhook delivery settings).
+- Configurable application settings from the in-app settings panel (unit label, webhook delivery settings, and roster management).
 - Optional per-entry webhook export that mirrors the CSV column structure so downstream tables align perfectly with local exports.
 - CSV and JSON export for the active show.
 - Entry editor modal with validation consistent with the original workflow.
@@ -30,7 +30,7 @@ This project exposes the **Drone Tracker** interface as a full web application b
 
    The app runs on [http://10.241.211.120:3000](http://10.241.211.120:3000) out of the box. Set the `HOST` and `PORT` environment variables before launching if you need a different binding (for example `HOST=0.0.0.0 node server/index.js`).
 
-3. Open the settings panel (gear icon) to adjust the SQL.js file location or to enable the webhook exporter. By default the app uses SQLite-on-WASM and stores data in `data/monkey-tracker.sqlite`.
+3. Open the settings panel (hamburger button) to adjust the unit label, manage pilot/monkey lead/crew rosters, or to enable the webhook exporter. By default the app uses SQLite-on-WASM and stores data in `data/monkey-tracker.sqlite`.
 
 ## Configuration
 
@@ -45,7 +45,11 @@ The runtime configuration is stored in `config/app-config.json` (created automat
 
 ### SQL.js storage
 
-- **filename** – path to the SQLite database file. The directory is created if it does not exist. Shows are stored as JSON documents inside the `shows` table.
+The SQLite database file is stored at `data/monkey-tracker.sqlite`. The directory is created if it does not exist and the file is managed automatically by the server.
+
+### Roster management
+
+The settings panel maintains individual lists for pilots, IATSE monkey leads, and crew. Monkey leads start with Cleo, Bret, Leslie, and Dallas by default and can be customized to match the day's roster.
 
 ### Webhook exporter
 

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,14 @@
         <button id="roleHome" class="btn ghost" type="button">← Choose role</button>
         <div class="grow"></div>
         <button id="refreshShows" type="button" class="btn ghost">Refresh data</button>
-        <button id="configBtn" class="btn icon-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings">⚙️</button>
+        <button id="configBtn" class="btn icon-btn hamburger-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings">
+          <span class="hamburger-icon" aria-hidden="true">
+            <span></span>
+            <span></span>
+            <span></span>
+          </span>
+          <span class="sr-only">Open settings</span>
+        </button>
       </div>
       <div class="row">
         <h1><span id="appTitle">Drone</span> Tracker</h1>
@@ -36,12 +43,6 @@
         </select>
         <p class="help">Controls how units are referenced across the UI.</p>
       </div>
-      <fieldset id="sqlFields" class="col-12 provider-fields">
-        <legend>SQL configuration</legend>
-        <label for="sqlFilename">SQLite database file</label>
-        <input id="sqlFilename" type="text" placeholder="data/monkey-tracker.sqlite" />
-        <p class="help">The server will create the file if it does not exist.</p>
-      </fieldset>
       <fieldset id="webhookFields" class="col-12 provider-fields">
         <legend>Webhook export</legend>
         <label class="switch">
@@ -63,10 +64,12 @@
         <div id="webhookPreview" class="webhook-preview" aria-live="polite"></div>
       </fieldset>
       <fieldset id="staffFields" class="col-12 provider-fields">
-        <legend>Pilots &amp; crew</legend>
+        <legend>Pilots, monkey leads &amp; crew</legend>
         <p class="help">Add one name per line. These lists feed the Lead and Pilot workspaces.</p>
         <label for="pilotList">Pilots</label>
         <textarea id="pilotList" class="list-input" placeholder="e.g., Alex"></textarea>
+        <label for="monkeyLeadList">Monkey leads</label>
+        <textarea id="monkeyLeadList" class="list-input" placeholder="e.g., Cleo"></textarea>
         <label for="crewList">Crew</label>
         <textarea id="crewList" class="list-input" placeholder="e.g., Jamie"></textarea>
       </fieldset>
@@ -100,7 +103,12 @@
     </section>
 
     <section class="panel view-lead-only" aria-labelledby="showHeaderTitle">
-      <h2 id="showHeaderTitle">Show header</h2>
+      <div class="panel-header">
+        <h2 id="showHeaderTitle">Show header</h2>
+        <div class="panel-actions">
+          <button id="newShow" class="btn primary">Add show</button>
+        </div>
+      </div>
       <div class="grid">
         <div class="col-3">
           <label for="showDate">Date</label>
@@ -239,18 +247,13 @@
           <label for="entryNotes">Notes</label>
           <input id="entryNotes" type="text" placeholder="Short note" />
         </div>
+        <div class="col-12 entry-actions">
+          <button id="addLine" class="btn primary">Add line</button>
+        </div>
       </div>
     </section>
 
     <section id="groups" class="view-lead-only"></section>
-  </div>
-
-  <div class="sticky-footer" role="contentinfo">
-    <div class="footer-grid">
-      <button id="newShow" class="btn span-4 view-lead-only">New Show</button>
-      <button id="dupShow" class="btn span-4 view-lead-only">Duplicate Current Show</button>
-      <button id="addLine" class="btn primary span-4 view-pilot-only">Add line</button>
-    </div>
   </div>
 
   <div id="editModal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="editTitle">

--- a/public/styles.css
+++ b/public/styles.css
@@ -38,7 +38,7 @@ a{color:var(--primary);text-decoration:none}
 .container{
   max-width:1100px;
   margin:0 auto;
-  padding:14px 16px 120px;
+  padding:14px 16px 48px;
 }
 #roleHome{display:none}
 body.view-lead #roleHome,
@@ -47,7 +47,6 @@ body.view-pilot #roleHome{display:inline-flex}
 body.view-lead #viewBadge,
 body.view-pilot #viewBadge{display:inline-flex}
 body.view-landing #refreshShows{display:none}
-body.view-landing .sticky-footer{display:none}
 .view-lead-only,
 .view-pilot-only,
 .view-landing-only{display:none !important}
@@ -174,29 +173,11 @@ input:focus, select:focus, textarea:focus, .btn:focus-visible, .chip-input input
 .btn.primary{background:var(--primary); border-color:var(--primary-2); color:#041423}
 .btn.ghost{background:transparent}
 .btn.icon-btn{width:var(--tap-min); height:var(--tap-min); display:inline-grid; place-items:center; border-radius:12px;}
-.sticky-footer{
-  position:fixed; inset:auto 0 0 0; z-index:60;
-  background:linear-gradient(to top, rgba(22,24,29,.98), rgba(25, 30, 41, 0.96) 60%, rgba(29, 34, 47, 0.92));
-  backdrop-filter:saturate(1.2) blur(8px);
-  padding:10px 16px calc(16px + env(safe-area-inset-bottom));
-  border-top:1px solid var(--border);
-}
-.footer-grid{
-  display:grid; gap:10px;
-  grid-template-columns: repeat(12, 1fr);
-  max-width:1100px;margin:0 auto;
-}
-.footer-grid .btn{min-width:100%}
-.footer-grid .span-2{grid-column:span 2}
-.footer-grid .span-3{grid-column:span 3}
-.footer-grid .span-4{grid-column:span 4}
-@media (max-width:1100px){
-  .footer-grid .span-2,.footer-grid .span-3,.footer-grid .span-4{grid-column:span 6}
-}
-@media (max-width:520px){
-  .footer-grid .span-2,.footer-grid .span-3,.footer-grid .span-4{grid-column:span 12}
-}
-
+.hamburger-btn{padding:0;}
+.hamburger-icon{display:inline-flex; flex-direction:column; gap:4px; align-items:center; justify-content:center;}
+.hamburger-icon span{display:block; width:20px; height:2px; background:var(--text); border-radius:999px;}
+.hamburger-btn:is(:hover,:focus-visible) .hamburger-icon span,
+.hamburger-btn.is-active .hamburger-icon span{background:var(--primary);}
 .chips{display:flex;gap:8px;flex-wrap:wrap}
 .chip{
   background:var(--chip); border:1px solid var(--border);
@@ -231,8 +212,17 @@ input:focus, select:focus, textarea:focus, .btn:focus-visible, .chip-input input
 
 details.group > summary{
   list-style:none; cursor:pointer; padding:14px; background:linear-gradient(180deg, rgba(255,255,255,.02), transparent);
-  display:flex; align-items:center; justify-content:space-between; gap:10px
 }
+details.group > summary .group-summary{
+  display:flex; align-items:center; justify-content:space-between; gap:12px;
+}
+.group-summary-meta{display:flex; align-items:center; gap:10px; flex-wrap:wrap}
+.show-menu-wrap{position:relative}
+.show-menu-btn{width:36px; height:36px; padding:0; min-height:36px;}
+.show-menu{position:absolute; right:0; top:calc(100% + 8px); background:var(--panel); border:1px solid var(--border); border-radius:12px; min-width:170px; box-shadow:var(--shadow); padding:8px; display:flex; flex-direction:column; gap:4px; opacity:0; pointer-events:none; transform:translateY(-6px); transition:opacity .2s ease, transform .2s ease; max-height:240px; overflow:auto; z-index:30;}
+.show-menu-wrap.open .show-menu{opacity:1; pointer-events:auto; transform:translateY(0);}
+.show-menu .menu-item{background:transparent; border:0; text-align:left; color:var(--text); padding:10px 12px; border-radius:10px; cursor:pointer; font:inherit;}
+.show-menu .menu-item:hover{background:#171b23}
 details.group[open] > summary{border-bottom:1px solid var(--border)}
 summary::-webkit-details-marker{display:none}
 .group-title{font-weight:800}
@@ -253,16 +243,6 @@ summary::-webkit-details-marker{display:none}
 .dot-warn{background:var(--warn)}
 .dot-danger{background:var(--danger)}
 
-.menu{position:relative}
-.menu-btn{background:var(--muted);border:1px solid var(--border); border-radius:10px; width:36px;height:36px; display:grid;place-items:center; cursor:pointer}
-.menu-list{
-  position:absolute; right:0; top:44px; background:#0f1217; border:1px solid var(--border); border-radius:12px; min-width:160px; z-index:10; box-shadow:var(--shadow);
-  display:none
-}
-.menu[open] .menu-list{display:block}
-.menu-item{display:block;width:100%; text-align:left; padding:12px 14px; background:transparent; border:0; color:var(--text); cursor:pointer}
-.menu-item:hover{background:#171b23}
-
 .modal-backdrop{
   position:fixed; inset:0; background:rgba(0,0,0,.55); display:none; align-items:center; justify-content:center; z-index:80; padding:16px
 }
@@ -270,7 +250,7 @@ summary::-webkit-details-marker{display:none}
 .modal-backdrop.open{display:flex}
 
 .toast{
-  position:fixed; left:50%; bottom:92px; transform:translateX(-50%);
+  position:fixed; left:50%; bottom:32px; transform:translateX(-50%);
   background:#0f131a; color:var(--text); border:1px solid var(--border); border-radius:999px; padding:12px 16px; z-index:100;
   box-shadow:var(--shadow); display:none
 }
@@ -280,6 +260,14 @@ summary::-webkit-details-marker{display:none}
 @keyframes pulseGlow{0%{box-shadow:0 0 0 0 rgba(31,198,122,.0)}50%{box-shadow:0 0 0 8px rgba(31,198,122,.18)}100%{box-shadow:0 0 0 0 rgba(31,198,122,.0)}}
 
 .toolbar{display:flex; gap:10px; align-items:center; justify-content:space-between}
+.panel-header{display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:12px; flex-wrap:wrap}
+.panel-actions{display:flex; gap:10px; align-items:center; flex-wrap:wrap}
+.entry-actions{display:flex; justify-content:flex-end; margin-top:4px}
+.entry-actions .btn{min-width:160px}
+@media (max-width:600px){
+  .entry-actions{justify-content:stretch}
+  .entry-actions .btn{width:100%}
+}
 .subtitle{color:var(--text-dim)}
 .sep{height:1px;background:var(--border);margin:10px 0}
 .config{
@@ -288,6 +276,8 @@ summary::-webkit-details-marker{display:none}
   opacity:0; transform:translateY(-12px) scale(.98);
   pointer-events:none; visibility:hidden;
   transition:opacity .25s ease, transform .25s ease;
+  max-height:calc(100vh - 80px);
+  overflow:auto;
 }
 .config.open{
   opacity:1; transform:translateY(0) scale(1);


### PR DESCRIPTION
## Summary
- Move the new show workflow into the lead panel, remove the sticky footer controls, and add a per-show options menu with duplication support.
- Restyle the header/settings controls with a hamburger trigger, inline the pilot "Add line" action, and make the settings drawer scrollable on small screens.
- Introduce a dedicated monkey lead roster (seeded with Cleo, Bret, Leslie, and Dallas) that is editable in settings and used by the lead workspace without relying on the pilot list.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d26bbee414832aa85aee518a4ba396