### PR TITLE
Implement left drawer menu with admin PIN gating

### DIFF
--- a/public/assets/sphere-logo.svg
+++ b/public/assets/sphere-logo.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="220" height="60" viewBox="0 0 220 60" role="img" aria-labelledby="title desc">
+  <title id="title">Sphere logo</title>
+  <desc id="desc">Gradient dome with the word sphere</desc>
+  <defs>
+    <linearGradient id="sphereGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#4dd3ff" />
+      <stop offset="55%" stop-color="#21a7d9" />
+      <stop offset="100%" stop-color="#0a4872" />
+    </linearGradient>
+    <linearGradient id="shineGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="rgba(255,255,255,.9)" />
+      <stop offset="70%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+    <clipPath id="domeClip">
+      <path d="M40 10c-16.568 0-30 13.432-30 30v4h60v-4c0-16.568-13.432-30-30-30z" />
+    </clipPath>
+  </defs>
+  <g clip-path="url(#domeClip)">
+    <rect x="10" y="10" width="60" height="40" fill="url(#sphereGradient)" rx="20" />
+    <rect x="10" y="10" width="60" height="24" fill="url(#shineGradient)" />
+  </g>
+  <path d="M10 40h60c0 6.627-13.432 12-30 12s-30-5.373-30-12z" fill="#0a1f30" opacity=".38" />
+  <text x="90" y="38" font-family="'Segoe UI','Inter','Helvetica Neue',sans-serif" font-size="26" font-weight="600" fill="#ffffff" letter-spacing="2">sphere</text>
+  <text x="164" y="25" font-family="'Segoe UI','Inter','Helvetica Neue',sans-serif" font-size="10" fill="#ffffff">™</text>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -2,96 +2,126 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Drone Tracker</title>
+  <title>Flight Log Form</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
-  <div class="topbar" role="banner">
-    <div class="toolbar">
-      <div class="row">
-        <button id="configBtn" class="btn icon-btn hamburger-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings">
-          <span class="hamburger-icon" aria-hidden="true">
-            <span></span>
-            <span></span>
-            <span></span>
-          </span>
-          <span class="sr-only">Open settings</span>
-        </button>
-        <button id="roleHome" class="btn ghost" type="button">← Choose role</button>
-        <div class="grow"></div>
-        <button id="refreshShows" type="button" class="btn ghost">Refresh data</button>
+  <div id="appShell" class="app-shell">
+    <aside id="configPanel" class="config" role="dialog" aria-modal="true" aria-labelledby="configTitle">
+      <div class="toolbar config-header">
+        <h2 id="configTitle">Workspace menu</h2>
+        <button id="closeConfig" class="btn icon-btn" title="Close settings">✖️</button>
       </div>
-      <div class="row">
-        <span id="viewBadge" class="view-badge">Lead workspace</span>
-        <h1><span id="appTitle">Drone</span> Tracker</h1>
-      </div>
-    </div>
-  </div>
-
-  <div id="configPanel" class="config" role="dialog" aria-modal="true" aria-labelledby="configTitle">
-    <div class="toolbar">
-      <h2 id="configTitle">Application settings</h2>
-      <button id="closeConfig" class="btn icon-btn" title="Close settings">✖️</button>
-    </div>
-    <form id="configForm" class="grid">
-      <div class="col-12">
-        <label for="unitLabelSelect">Unit label</label>
-        <select id="unitLabelSelect" name="unitLabel">
-          <option value="Drone">Drone</option>
-          <option value="Monkey">Monkey</option>
-        </select>
-        <p class="help">Controls how units are referenced across the UI.</p>
-      </div>
-      <fieldset id="webhookFields" class="col-12 provider-fields">
-        <legend>Webhook export</legend>
-        <label class="switch">
-          <input id="webhookEnabled" type="checkbox" />
-          <span>Enable per-entry webhook dispatch</span>
-        </label>
-        <p class="help">Send each recorded entry to an external endpoint using the same columns as the CSV export.</p>
-        <label for="webhookUrl">Webhook URL</label>
-        <input id="webhookUrl" type="url" autocomplete="off" placeholder="https://example.com/webhook" />
-        <label for="webhookMethod">HTTP method</label>
-        <select id="webhookMethod">
-          <option>POST</option>
-          <option>PUT</option>
-        </select>
-        <label for="webhookSecret">Shared secret (optional)</label>
-        <input id="webhookSecret" type="text" autocomplete="off" placeholder="Used for X-Drone-Webhook-Secret header" />
-        <label for="webhookHeaders">Additional headers (optional)</label>
-        <textarea id="webhookHeaders" placeholder="One per line, e.g., Authorization: Bearer token"></textarea>
-        <div id="webhookPreview" class="webhook-preview" aria-live="polite"></div>
-      </fieldset>
-      <fieldset id="staffFields" class="col-12 provider-fields">
-        <legend>Pilots, monkey leads &amp; crew</legend>
-        <p class="help">Add one name per line. These lists feed the Lead and Pilot workspaces.</p>
-        <label for="pilotList">Pilots</label>
-        <textarea id="pilotList" class="list-input" placeholder="e.g., Alex"></textarea>
-        <label for="monkeyLeadList">Monkey leads</label>
-        <textarea id="monkeyLeadList" class="list-input" placeholder="e.g., Cleo"></textarea>
-        <label for="crewList">Crew</label>
-        <textarea id="crewList" class="list-input" placeholder="e.g., Jamie"></textarea>
-      </fieldset>
-      <fieldset id="exportFields" class="col-12 provider-fields">
-        <legend>Lead exports</legend>
-        <p class="help">Download the currently selected show for offline analysis.</p>
-        <div class="row" style="justify-content:flex-start; gap:10px;">
-          <button type="button" id="leadExportCsv" class="btn ghost">Export CSV</button>
-          <button type="button" id="leadExportJson" class="btn ghost">Export JSON</button>
+      <nav class="config-nav" aria-label="Settings categories">
+        <button type="button" class="config-nav-btn is-active" data-config-target="lead">Lead settings</button>
+        <button type="button" class="config-nav-btn" data-config-target="admin">Admin settings</button>
+      </nav>
+      <div id="adminPinPrompt" class="pin-prompt" role="alertdialog" aria-modal="true" aria-labelledby="adminPinTitle" hidden>
+        <div class="pin-card">
+          <h3 id="adminPinTitle">Admin PIN required</h3>
+          <p class="help">Enter the 4-digit PIN to continue.</p>
+          <label for="adminPinInput">PIN</label>
+          <input id="adminPinInput" type="password" inputmode="numeric" pattern="[0-9]*" maxlength="4" autocomplete="off" aria-describedby="adminPinHelp" />
+          <p id="adminPinHelp" class="help">Use PIN 4206.</p>
+          <div class="row pin-actions">
+            <button type="button" id="adminPinCancel" class="btn ghost">Cancel</button>
+            <button type="button" id="adminPinSubmit" class="btn primary">Unlock</button>
+          </div>
+          <div id="adminPinError" class="error" role="alert" hidden>Incorrect PIN. Try again.</div>
         </div>
-      </fieldset>
-      <div class="col-12 row" style="justify-content: flex-end; gap: 10px;">
-        <button type="button" id="cancelConfig" class="btn ghost">Cancel</button>
-        <button type="submit" class="btn primary">Save settings</button>
       </div>
-      <div class="col-12">
-        <div id="configMessage" role="status" aria-live="polite" class="help"></div>
-      </div>
-    </form>
-  </div>
+      <form id="configForm" class="config-form">
+        <section class="config-section grid is-active" data-config-section="lead">
+          <fieldset id="staffFields" class="col-12 provider-fields">
+            <legend>Pilots, monkey leads &amp; crew</legend>
+            <p class="help">Add one name per line. These lists feed the Lead and Pilot workspaces.</p>
+            <label for="pilotList">Pilots</label>
+            <textarea id="pilotList" class="list-input" placeholder="e.g., Alex"></textarea>
+            <label for="monkeyLeadList">Monkey leads</label>
+            <textarea id="monkeyLeadList" class="list-input" placeholder="e.g., Cleo"></textarea>
+            <label for="crewList">Crew</label>
+            <textarea id="crewList" class="list-input" placeholder="e.g., Jamie"></textarea>
+          </fieldset>
+          <fieldset id="exportFields" class="col-12 provider-fields">
+            <legend>Lead exports</legend>
+            <p class="help">Download the currently selected show for offline analysis.</p>
+            <div class="row" style="justify-content:flex-start; gap:10px;">
+              <button type="button" id="leadExportCsv" class="btn ghost">Export CSV</button>
+              <button type="button" id="leadExportJson" class="btn ghost">Export JSON</button>
+            </div>
+          </fieldset>
+        </section>
+        <section class="config-section grid" data-config-section="admin" aria-hidden="true">
+          <div class="col-12">
+            <label for="unitLabelSelect">Unit label</label>
+            <select id="unitLabelSelect" name="unitLabel">
+              <option value="Drone">Drone</option>
+              <option value="Monkey">Monkey</option>
+            </select>
+            <p class="help">Controls how units are referenced across the UI.</p>
+          </div>
+          <fieldset id="webhookFields" class="col-12 provider-fields">
+            <legend>Webhook export</legend>
+            <label class="switch">
+              <input id="webhookEnabled" type="checkbox" />
+              <span>Enable per-entry webhook dispatch</span>
+            </label>
+            <p class="help">Send each recorded entry to an external endpoint using the same columns as the CSV export.</p>
+            <label for="webhookUrl">Webhook URL</label>
+            <input id="webhookUrl" type="url" autocomplete="off" placeholder="https://example.com/webhook" />
+            <label for="webhookMethod">HTTP method</label>
+            <select id="webhookMethod">
+              <option>POST</option>
+              <option>PUT</option>
+            </select>
+            <label for="webhookSecret">Shared secret (optional)</label>
+            <input id="webhookSecret" type="text" autocomplete="off" placeholder="Used for X-Drone-Webhook-Secret header" />
+            <label for="webhookHeaders">Additional headers (optional)</label>
+            <textarea id="webhookHeaders" placeholder="One per line, e.g., Authorization: Bearer token"></textarea>
+            <div id="webhookPreview" class="webhook-preview" aria-live="polite"></div>
+          </fieldset>
+        </section>
+        <div class="config-actions row">
+          <div class="grow"></div>
+          <button type="button" id="cancelConfig" class="btn ghost">Cancel</button>
+          <button type="submit" class="btn primary">Save settings</button>
+        </div>
+        <div class="config-status">
+          <div id="configMessage" role="status" aria-live="polite" class="help"></div>
+        </div>
+      </form>
+    </aside>
 
-  <div class="container" role="main">
+    <div id="appMain" class="app-main">
+      <div class="topbar" role="banner">
+        <div class="toolbar topbar-toolbar">
+          <div class="topbar-section topbar-left">
+            <button id="configBtn" class="btn icon-btn hamburger-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings">
+              <span class="hamburger-icon" aria-hidden="true">
+                <span></span>
+                <span></span>
+                <span></span>
+              </span>
+              <span class="sr-only">Open settings</span>
+            </button>
+            <img src="./assets/sphere-logo.svg" alt="Sphere" class="app-logo" />
+          </div>
+          <div class="topbar-section topbar-center">
+            <button id="roleHome" class="btn ghost" type="button">← Choose role</button>
+            <button id="refreshShows" type="button" class="btn ghost">Refresh data</button>
+          </div>
+          <div class="topbar-section topbar-right">
+            <span id="viewBadge" class="view-badge">Lead workspace</span>
+            <div class="title-stack">
+              <h1 class="app-title">Flight Log Form</h1>
+              <span class="title-sub">Tracking <span id="appTitle">Drone</span> activity</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="container" role="main">
     <section id="landingView" class="panel landing-panel view-landing-only" aria-labelledby="landingTitle">
       <h2 id="landingTitle">Choose workspace</h2>
       <p class="lead">Select the role you need for this session.</p>
@@ -255,6 +285,8 @@
 
     <section id="groups" class="view-lead-only"></section>
   </div>
+</div>
+</div>
 
   <div id="editModal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="editTitle">
     <div class="modal">

--- a/public/styles.css
+++ b/public/styles.css
@@ -20,6 +20,7 @@
   --gap:12px;
   --tap-min:44px;
   --fz:16px;
+  --drawer-width:320px;
 }
 *{box-sizing:border-box}
 html,body{height:100%}
@@ -83,12 +84,40 @@ body.view-landing #landingView{display:block}
   color:var(--success);
 }
 #pilotShowSummary{margin-top:8px;padding:10px 12px;border:1px dashed var(--border);border-radius:10px;background:rgba(255,255,255,.03);color:var(--text-dim);font-size:13px;text-align:left}
+.app-shell{position:relative;min-height:100vh;overflow-x:hidden;}
+.app-main{position:relative;transition:transform .35s ease, filter .35s ease;will-change:transform;}
+body.menu-open{overflow-x:hidden;}
+body.menu-open .app-main{transform:translateX(calc(min(var(--drawer-width), 92vw)));}
 .topbar{
   position:sticky;top:0;z-index:50;
   background:linear-gradient(to bottom, rgba(14,15,18,.95), rgba(14,15,18,.85) 60%, transparent);
   backdrop-filter:saturate(1.2) blur(8px);
   padding:10px 16px 6px;
   border-bottom:1px solid var(--border);
+}
+.topbar-toolbar{
+  flex-direction:row;
+  align-items:center;
+  justify-content:space-between;
+  gap:16px;
+  flex-wrap:wrap;
+}
+.topbar-section{display:flex;align-items:center;gap:12px;flex-wrap:wrap;}
+.topbar-left{flex:1 1 200px;min-width:200px;}
+.topbar-center{flex:1 1 240px;justify-content:center;}
+.topbar-center .btn{min-width:150px;}
+.topbar-right{flex:1 1 220px;flex-direction:column;align-items:flex-end;gap:6px;text-align:right;}
+.app-logo{display:block;height:36px;width:auto;max-width:160px;filter:drop-shadow(0 8px 16px rgba(0,0,0,.45));}
+.title-stack{display:flex;flex-direction:column;align-items:flex-end;gap:4px;}
+.app-title{margin:0;font-size:22px;}
+.title-sub{font-size:12px;color:var(--text-dim);text-transform:uppercase;letter-spacing:.12em;}
+@media (max-width:720px){
+  .topbar-toolbar{flex-direction:column;align-items:stretch;}
+  .topbar-section{justify-content:space-between;}
+  .topbar-right{align-items:flex-start;text-align:left;}
+  .title-stack{align-items:flex-start;}
+  .topbar-center{flex-direction:column;align-items:stretch;}
+  .topbar-center .btn{width:100%;min-width:0;}
 }
 .row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
 .grow{flex:1}
@@ -345,17 +374,85 @@ summary::-webkit-details-marker{display:none}
 .subtitle{color:var(--text-dim)}
 .sep{height:1px;background:var(--border);margin:10px 0}
 .config{
-  position:fixed; right:16px; top:54px; width:min(420px, 92vw); background:var(--panel); border:1px solid var(--border);
-  border-radius:16px; padding:14px; z-index:70; box-shadow:var(--shadow);
-  opacity:0; transform:translateY(-12px) scale(.98);
-  pointer-events:none; visibility:hidden;
-  transition:opacity .25s ease, transform .25s ease;
-  max-height:calc(100vh - 80px);
-  overflow:auto;
+  position:fixed;
+  left:0;
+  top:0;
+  bottom:0;
+  width:calc(min(var(--drawer-width), 92vw));
+  background:var(--panel);
+  border-right:1px solid var(--border);
+  border-radius:0 18px 18px 0;
+  padding:20px 18px 24px;
+  z-index:80;
+  box-shadow:0 18px 40px rgba(0,0,0,.45);
+  opacity:0;
+  transform:translateX(-105%);
+  pointer-events:none;
+  visibility:hidden;
+  transition:transform .35s ease, opacity .25s ease;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
 }
 .config.open{
-  opacity:1; transform:translateY(0) scale(1);
-  pointer-events:auto; visibility:visible;
+  opacity:1;
+  transform:translateX(0);
+  pointer-events:auto;
+  visibility:visible;
+}
+.config-header{margin-bottom:4px;}
+.config-nav{display:flex;gap:8px;}
+.config-nav-btn{
+  flex:1;
+  border-radius:12px;
+  border:1px solid var(--border);
+  background:rgba(255,255,255,.04);
+  color:var(--text-dim);
+  padding:10px 12px;
+  font-weight:700;
+  cursor:pointer;
+  transition:background .2s ease, color .2s ease, border-color .2s ease;
+}
+.config-nav-btn:hover{background:rgba(255,255,255,.08);color:var(--text);}
+.config-nav-btn.is-active{
+  background:var(--primary);
+  border-color:var(--primary-2);
+  color:#041423;
+}
+.config-form{flex:1;overflow:auto;display:flex;flex-direction:column;gap:18px;position:relative;}
+.config-section{display:none;gap:12px;}
+.config-section.is-active{display:grid;}
+.config-actions{justify-content:flex-end;gap:10px;flex-wrap:wrap;}
+.config-status{min-height:20px;color:var(--text-dim);}
+.pin-prompt{
+  position:absolute;
+  inset:0;
+  background:rgba(6,9,14,.82);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:20px;
+  z-index:5;
+  backdrop-filter:blur(4px);
+}
+.pin-prompt[hidden]{display:none;}
+.pin-card{
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  padding:20px;
+  width:100%;
+  max-width:280px;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  box-shadow:var(--shadow);
+}
+.pin-card input{letter-spacing:.4em;text-align:center;font-weight:700;}
+.pin-actions{justify-content:flex-end;}
+@media (max-width:720px){
+  body.menu-open .app-main{transform:translateX(calc(min(var(--drawer-width), 86vw)));}
+  .config{padding:18px 14px 24px;}
 }
 .provider-fields{border:1px solid var(--border); border-radius:12px; padding:12px}
 .provider-fields legend{font-weight:700}


### PR DESCRIPTION
## Summary
- add a sliding left-side drawer for the hamburger menu that shifts the workspace and adopts the new Flight Log Form branding with the provided logo
- reorganize settings into lead and admin sections and require the 4206 PIN before revealing admin controls
- update the header layout so the workspace badge and title sit on the right and rename the experience to Flight Log Form

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d301bd8878832abc002872a207f668