### PR TITLE
Adjust header layout and admin PIN handling

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1454,6 +1454,12 @@ function toggleConfig(open){
 
 function setConfigSection(section){
   currentConfigSection = section;
+  if(section !== 'admin'){
+    if(adminUnlocked){
+      adminUnlocked = false;
+    }
+    closeAdminPinPrompt();
+  }
   if(configSections.length){
     configSections.forEach(sec=>{
       const isActive = sec.dataset.configSection === section;

--- a/public/index.html
+++ b/public/index.html
@@ -101,7 +101,7 @@
     <div id="appMain" class="app-main">
       <div class="topbar" role="banner">
         <div class="toolbar topbar-toolbar">
-          <div class="topbar-section topbar-left">
+          <div class="topbar-actions">
             <button id="configBtn" class="btn icon-btn hamburger-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings">
               <span class="hamburger-icon" aria-hidden="true">
                 <span></span>
@@ -110,12 +110,10 @@
               </span>
               <span class="sr-only">Open settings</span>
             </button>
-            <img src="./assets/Sphere%20Logo_RGB%20_White.png" alt="Sphere" class="app-logo" />
-          </div>
-          <div class="topbar-section topbar-center">
             <button id="roleHome" class="btn ghost" type="button">← Choose role</button>
           </div>
-          <div class="topbar-section topbar-right">
+          <img src="./assets/Sphere%20Logo_RGB%20_White.png" alt="Sphere" class="app-logo" />
+          <div class="topbar-title">
             <span id="viewBadge" class="view-badge">Lead workspace</span>
             <div class="title-stack">
               <h1 class="app-title">Flight Log Form</h1>

--- a/public/styles.css
+++ b/public/styles.css
@@ -59,7 +59,19 @@ body.view-pilot .view-pilot-only{display:block !important}
 body.view-landing .view-landing-only{display:block !important}
 #landingView{display:none;text-align:center;padding:38px 20px}
 body.view-landing #landingView{display:block}
-.role-options{display:flex;gap:16px;justify-content:center;flex-wrap:wrap;margin-top:22px}
+.role-options{
+  display:inline-flex;
+  gap:16px;
+  justify-content:center;
+  flex-wrap:wrap;
+  margin:22px auto 0;
+  padding:24px 28px;
+  border-radius:20px;
+  background:rgba(14,16,22,.72);
+  border:1px solid rgba(255,255,255,.08);
+  box-shadow:0 20px 40px rgba(0,0,0,.28);
+  backdrop-filter:blur(6px);
+}
 .role-btn{min-width:160px;font-size:18px;padding:18px 26px}
 .view-badge{
   background:transparent;
@@ -97,35 +109,43 @@ body.menu-open .app-main{transform:translateX(calc(min(var(--drawer-width), 92vw
   z-index:50;
   background:linear-gradient(to bottom, rgba(14,15,18,.95), rgba(14,15,18,.85) 60%, transparent);
   backdrop-filter:saturate(1.2) blur(8px);
-  padding:12px 24px;
+  padding:10px 20px;
   border-bottom:1px solid var(--border);
 }
 .topbar-toolbar{
   flex-direction:row;
   align-items:center;
-  justify-content:space-between;
-  gap:20px;
+  gap:16px;
   flex-wrap:nowrap;
-  min-height:72px;
+  min-height:60px;
 }
-.topbar-section{display:flex;align-items:center;gap:12px;}
-.topbar-left,.topbar-center,.topbar-right{flex:0 1 auto;}
-.topbar-left{gap:16px;}
-.topbar-center{justify-content:center;min-width:160px;}
-.topbar-center .btn{min-width:140px;}
-.topbar-right{flex-direction:column;align-items:flex-end;gap:4px;text-align:right;}
-.app-logo{display:block;height:30px;width:auto;max-width:160px;filter:drop-shadow(0 8px 16px rgba(0,0,0,.45));}
+.topbar-actions{
+  display:flex;
+  align-items:center;
+  gap:10px;
+}
+body.view-lead .topbar-actions,
+body.view-pilot .topbar-actions{flex:1 1 auto;}
+.topbar-title{
+  margin-left:auto;
+  display:flex;
+  flex-direction:column;
+  align-items:flex-end;
+  gap:4px;
+  text-align:right;
+  flex:0 0 auto;
+}
+.app-logo{display:block;height:26px;width:auto;max-width:150px;filter:drop-shadow(0 8px 16px rgba(0,0,0,.45));flex:0 0 auto;}
 .title-stack{display:flex;flex-direction:column;align-items:flex-end;gap:4px;}
+.topbar-title .view-badge{align-self:flex-end;}
 .app-title{margin:0;font-size:22px;}
 .title-sub{font-size:12px;color:var(--text-dim);text-transform:uppercase;letter-spacing:.12em;}
 @media (max-width:720px){
-  .topbar{padding:12px 16px;}
-  .topbar-toolbar{flex-wrap:wrap;gap:12px;min-height:0;}
-  .topbar-section{justify-content:space-between;flex:1 1 100%;flex-wrap:wrap;}
-  .topbar-center{justify-content:flex-start;}
-  .topbar-right{align-items:flex-start;text-align:left;}
+  .topbar{padding:10px 16px;}
+  .topbar-toolbar{flex-direction:column;align-items:flex-start;gap:10px;min-height:0;}
+  .topbar-actions{width:100%;gap:8px;}
+  .topbar-title{margin-left:0;align-items:flex-start;text-align:left;width:100%;}
   .title-stack{align-items:flex-start;}
-  .topbar-center .btn{width:100%;min-width:0;}
 }
 .row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
 .grow{flex:1}


### PR DESCRIPTION
## Summary
- reorganize the topbar so the hamburger, workspace back button, Sphere logo, view badge, and title render in the requested order while trimming the header height
- style the landing role selector with a semi-transparent overlay panel to sit over the background artwork
- reset the admin PIN lock whenever the settings drawer closes or the Lead settings tab is opened after an unlock

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d31315cf94832a80323f1eee4390e8