### PR TITLE
Adjust header layout and landing styles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,8 +22,7 @@
           <h3 id="adminPinTitle">Admin PIN required</h3>
           <p class="help">Enter the 4-digit PIN to continue.</p>
           <label for="adminPinInput">PIN</label>
-          <input id="adminPinInput" type="password" inputmode="numeric" pattern="[0-9]*" maxlength="4" autocomplete="off" aria-describedby="adminPinHelp" />
-          <p id="adminPinHelp" class="help">Use PIN 4206.</p>
+          <input id="adminPinInput" type="password" inputmode="numeric" pattern="[0-9]*" maxlength="4" autocomplete="off" />
           <div class="row pin-actions">
             <button type="button" id="adminPinCancel" class="btn ghost">Cancel</button>
             <button type="button" id="adminPinSubmit" class="btn primary">Unlock</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -113,38 +113,68 @@ body.menu-open .app-main{transform:translateX(calc(min(var(--drawer-width), 92vw
   border-bottom:1px solid var(--border);
 }
 .topbar-toolbar{
-  flex-direction:row;
+  display:grid;
+  grid-template-columns:auto 1fr auto;
+  grid-template-areas:"actions title logo";
   align-items:center;
   gap:16px;
-  flex-wrap:nowrap;
   min-height:60px;
+  width:100%;
 }
 .topbar-actions{
+  grid-area:actions;
   display:flex;
   align-items:center;
   gap:10px;
+  justify-self:start;
 }
 body.view-lead .topbar-actions,
-body.view-pilot .topbar-actions{flex:1 1 auto;}
+body.view-pilot .topbar-actions{
+  justify-self:start;
+}
 .topbar-title{
-  margin-left:auto;
+  grid-area:title;
+  margin-left:0;
   display:flex;
   flex-direction:column;
   align-items:flex-end;
   gap:4px;
   text-align:right;
-  flex:0 0 auto;
+  justify-self:end;
 }
-.app-logo{display:block;height:26px;width:auto;max-width:150px;filter:drop-shadow(0 8px 16px rgba(0,0,0,.45));flex:0 0 auto;}
+.app-logo{
+  grid-area:logo;
+  display:block;
+  height:26px;
+  width:auto;
+  max-width:150px;
+  filter:drop-shadow(0 8px 16px rgba(0,0,0,.45));
+  justify-self:end;
+}
 .title-stack{display:flex;flex-direction:column;align-items:flex-end;gap:4px;}
 .topbar-title .view-badge{align-self:flex-end;}
 .app-title{margin:0;font-size:22px;}
 .title-sub{font-size:12px;color:var(--text-dim);text-transform:uppercase;letter-spacing:.12em;}
 @media (max-width:720px){
   .topbar{padding:10px 16px;}
-  .topbar-toolbar{flex-direction:column;align-items:flex-start;gap:10px;min-height:0;}
-  .topbar-actions{width:100%;gap:8px;}
-  .topbar-title{margin-left:0;align-items:flex-start;text-align:left;width:100%;}
+  .topbar-toolbar{
+    grid-template-columns:auto 1fr;
+    grid-template-areas:
+      "actions logo"
+      "title title";
+    gap:10px;
+    min-height:0;
+  }
+  .topbar-actions{
+    width:100%;
+    gap:8px;
+  }
+  .topbar-title{
+    justify-self:stretch;
+    align-items:flex-start;
+    text-align:left;
+    width:100%;
+  }
   .title-stack{align-items:flex-start;}
 }
 .row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
@@ -162,6 +192,11 @@ body.view-pilot .topbar-actions{flex:1 1 auto;}
   position:relative;
   animation:panelIn .45s ease;
   transition:transform .25s ease, box-shadow .25s ease;
+}
+.landing-panel{
+  background:rgba(22,24,29,.76);
+  border-color:rgba(255,255,255,.18);
+  backdrop-filter:blur(8px);
 }
 .panel:hover{transform:translateY(-2px); box-shadow:0 16px 40px rgba(0,0,0,.45);}
 .info-panel{padding:20px;display:flex}


### PR DESCRIPTION
## Summary
- rework the top bar layout so the hamburger stays on the left and the Sphere logo is fixed to the right across breakpoints
- make the landing "Choose workspace" panel semi-transparent to let the background imagery show through
- remove the hardcoded admin PIN hint from the settings dialog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d31839ac3c832a932e9bde9087e3c9