### PR TITLE
Implement archived shows retention and workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project exposes the **Drone Tracker** interface as a full web application b
 - SQL.js storage provider (v2) implemented with `sql.js` so no native builds are required. The server creates the database file if it does not exist.
 - Configurable application settings from the in-app settings panel (unit label, webhook delivery settings, and roster management).
 - Optional per-entry webhook export that mirrors the CSV column structure so downstream tables align perfectly with local exports.
-- CSV and JSON export for the active show.
+- Archive workspace that retains shows for two months and supports CSV/JSON exports.
 - Entry editor modal with validation consistent with the original workflow.
 
 ## Getting Started

--- a/public/index.html
+++ b/public/index.html
@@ -42,14 +42,6 @@
             <label for="crewList">Crew</label>
             <textarea id="crewList" class="list-input" placeholder="e.g., Jamie"></textarea>
           </fieldset>
-          <fieldset id="exportFields" class="col-12 provider-fields">
-            <legend>Lead exports</legend>
-            <p class="help">Download the currently selected show for offline analysis.</p>
-            <div class="row" style="justify-content:flex-start; gap:10px;">
-              <button type="button" id="leadExportCsv" class="btn ghost">Export CSV</button>
-              <button type="button" id="leadExportJson" class="btn ghost">Export JSON</button>
-            </div>
-          </fieldset>
         </section>
         <section class="config-section grid" data-config-section="admin" aria-hidden="true">
           <div class="col-12">
@@ -129,8 +121,33 @@
       <div class="role-options">
         <button id="chooseLead" type="button" class="btn primary role-btn">Lead</button>
         <button id="choosePilot" type="button" class="btn role-btn">Pilot</button>
+        <button id="chooseArchive" type="button" class="btn ghost role-btn">Archive</button>
       </div>
       <p class="help">Lead sets up shows and manages exports. Pilot logs entries against those shows.</p>
+    </section>
+
+    <section id="archiveView" class="panel view-archive-only" aria-labelledby="archiveTitle">
+      <div class="panel-header">
+        <h2 id="archiveTitle">Archived shows</h2>
+        <div class="panel-actions">
+          <button id="refreshArchive" type="button" class="btn ghost">Refresh archive</button>
+        </div>
+      </div>
+      <div class="grid archive-grid">
+        <div class="col-4">
+          <label for="archiveShowSelect">Archived show</label>
+          <select id="archiveShowSelect"></select>
+          <p id="archiveMeta" class="help"></p>
+        </div>
+        <div class="col-8">
+          <div id="archiveDetails" class="archive-details"></div>
+          <div id="archiveEmpty" class="help">No archived shows yet. Shows are moved here 24 hours after creation and remain available for two months.</div>
+          <div class="archive-actions row">
+            <button id="archiveExportCsv" type="button" class="btn ghost" disabled>Export CSV</button>
+            <button id="archiveExportJson" type="button" class="btn ghost" disabled>Export JSON</button>
+          </div>
+        </div>
+      </div>
     </section>
 
     <section class="panel view-lead-only" aria-labelledby="showHeaderTitle">

--- a/public/styles.css
+++ b/public/styles.css
@@ -46,17 +46,21 @@ a{color:var(--primary);text-decoration:none}
 }
 #roleHome{display:none}
 body.view-lead #roleHome,
-body.view-pilot #roleHome{display:inline-flex}
+body.view-pilot #roleHome,
+body.view-archive #roleHome{display:inline-flex}
 #viewBadge{display:none}
 body.view-lead #viewBadge,
-body.view-pilot #viewBadge{display:inline-flex}
+body.view-pilot #viewBadge,
+body.view-archive #viewBadge{display:inline-flex}
 body.view-landing #refreshShows{display:none}
 .view-lead-only,
 .view-pilot-only,
-.view-landing-only{display:none !important}
+.view-landing-only,
+.view-archive-only{display:none !important}
 body.view-lead .view-lead-only{display:block !important}
 body.view-pilot .view-pilot-only{display:block !important}
 body.view-landing .view-landing-only{display:block !important}
+body.view-archive .view-archive-only{display:block !important}
 #landingView{display:none;text-align:center;padding:38px 20px}
 body.view-landing #landingView{display:block}
 .role-options{
@@ -198,6 +202,48 @@ body.view-pilot .topbar-actions{
   border-color:rgba(255,255,255,.18);
   backdrop-filter:blur(8px);
 }
+.archive-grid{align-items:flex-start;gap:20px;}
+.archive-details{min-height:140px;}
+.archive-card{
+  background:var(--input);
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  padding:16px;
+}
+.archive-info{
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(160px,1fr));
+  gap:12px;
+}
+.archive-info div{border:none;padding:0;}
+.archive-info dt{
+  margin:0 0 4px;
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:.08em;
+  color:var(--text-dim);
+}
+.archive-info dd{
+  margin:0;
+  font-size:15px;
+  color:var(--text);
+}
+.archive-notes{
+  margin-top:16px;
+  padding-top:12px;
+  border-top:1px solid var(--border);
+}
+.archive-notes h3{
+  margin:0 0 6px;
+  font-size:13px;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  color:var(--text-dim);
+}
+.archive-notes p{margin:0;font-size:14px;line-height:1.4;color:var(--text);}
+.archive-actions{margin-top:16px;justify-content:flex-start;}
+#archiveMeta{margin-top:8px;color:var(--text-dim);font-size:13px;}
+#archiveEmpty{margin-top:12px;color:var(--text-dim);font-size:14px;}
 .panel:hover{transform:translateY(-2px); box-shadow:0 16px 40px rgba(0,0,0,.45);}
 .info-panel{padding:20px;display:flex}
 .info-grid{display:flex;flex-direction:column;gap:18px;width:100%}

--- a/scripts/simulate-archive.js
+++ b/scripts/simulate-archive.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+const { initProvider } = require('../server/storage');
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+async function main(){
+  const dbPath = path.join(process.cwd(), 'data', 'archive-sim.sqlite');
+  await fs.promises.mkdir(path.dirname(dbPath), {recursive: true});
+  await fs.promises.rm(dbPath, {force: true});
+
+  const provider = await initProvider({sql: {filename: dbPath}});
+
+  const totalDays = 70;
+  const showsPerDay = 2;
+  const now = Date.now();
+  const start = now - ((totalDays + 2) * DAY_IN_MS);
+
+  for(let day = 0; day < totalDays; day += 1){
+    const dayTimestamp = start + (day * DAY_IN_MS);
+    const dateStr = new Date(dayTimestamp).toISOString().slice(0, 10);
+    for(let index = 0; index < showsPerDay; index += 1){
+      const showTimestamp = dayTimestamp + (index * 60 * 60 * 1000);
+      await provider.createShow({
+        date: dateStr,
+        time: `${String(9 + index).padStart(2, '0')}:00`,
+        label: `Simulated show ${day + 1}-${index + 1}`,
+        crew: ['Sim Crew'],
+        leadPilot: 'Sim Lead',
+        monkeyLead: 'Sim Monkey',
+        notes: 'Archive simulation record',
+        createdAt: showTimestamp,
+        updatedAt: showTimestamp
+      });
+    }
+  }
+
+  await provider.runArchiveMaintenance();
+
+  const activeShows = await provider.listShows();
+  const archivedShows = await provider.listArchivedShows();
+
+  const expiredArchived = archivedShows.filter(show => {
+    const createdAt = Number(show.createdAt);
+    if(!Number.isFinite(createdAt)){
+      return false;
+    }
+    const expiry = new Date(createdAt);
+    expiry.setMonth(expiry.getMonth() + 2);
+    return Date.now() >= expiry.getTime();
+  });
+
+  console.log(`Active shows remaining: ${activeShows.length}`);
+  console.log(`Archived shows stored: ${archivedShows.length}`);
+  console.log(`Expired archived shows detected (should be 0): ${expiredArchived.length}`);
+
+  await provider.dispose();
+  await fs.promises.rm(dbPath, {force: true});
+}
+
+main().catch(err =>{
+  console.error('Archive simulation failed', err);
+  process.exit(1);
+});

--- a/server/index.js
+++ b/server/index.js
@@ -78,6 +78,12 @@ async function bootstrap(){
     res.json({storage: 'sql.js v2', webhook: getWebhookStatus(), shows});
   }));
 
+  app.get('/api/shows/archive', asyncHandler(async (req, res)=>{
+    const provider = getProvider();
+    const shows = await provider.listArchivedShows();
+    res.json({shows});
+  }));
+
   app.post('/api/shows', asyncHandler(async (req, res)=>{
     const provider = getProvider();
     const show = await provider.createShow(req.body || {});


### PR DESCRIPTION
## Summary
- add an archive table with 24-hour grouping, a two-month purge routine, and an archive listing API
- add an archive workspace with landing navigation, archived show summaries, and CSV/JSON export while removing lead exports
- provide a simulation script and update documentation to cover the archive feature

## Testing
- node scripts/simulate-archive.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d31cdd7090832aba1f0a5952d49707