### PR TITLE
Make show header required and support deleting shows

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -153,28 +153,23 @@
       <div class="grid">
         <div class="col-3">
           <label for="showDate">Date</label>
-          <input id="showDate" type="date" autocomplete="off" />
+          <input id="showDate" type="date" autocomplete="off" required />
         </div>
         <div class="col-3">
           <label for="showTime">Show start time</label>
-          <input id="showTime" type="time" />
+          <input id="showTime" type="time" required />
         </div>
         <div class="col-6">
           <label for="showLabel">Show label or number</label>
-          <input id="showLabel" type="text" placeholder="e.g., 7pm Main" />
+          <input id="showLabel" type="text" placeholder="e.g., 7pm Main" required />
         </div>
         <div class="col-6">
-          <label for="showCrew">Crew on duty</label>
-          <select id="showCrew" multiple></select>
-          <p class="help">Hold Ctrl (Cmd on Mac) or Shift to select multiple crew members.</p>
-        </div>
-        <div class="col-3">
           <label for="leadPilot">Lead Pilot</label>
-          <select id="leadPilot"></select>
+          <select id="leadPilot" required></select>
         </div>
-        <div class="col-3">
+        <div class="col-6">
           <label for="monkeyLead">Monkey Lead</label>
-          <select id="monkeyLead"></select>
+          <select id="monkeyLead" required></select>
         </div>
         <div class="col-12">
           <label for="showNotes">Notes for the show</label>

--- a/public/styles.css
+++ b/public/styles.css
@@ -465,6 +465,14 @@ input:focus, select:focus, textarea:focus, .btn:focus-visible, .chip-input input
   border-color:var(--focus);
   box-shadow:0 0 0 3px rgba(154, 210, 255, 0.95);
 }
+input.is-invalid, select.is-invalid, textarea.is-invalid{
+  border-color:var(--danger);
+  box-shadow:0 0 0 1px rgba(255, 93, 93, 0.4);
+}
+input.is-invalid:focus, select.is-invalid:focus, textarea.is-invalid:focus{
+  border-color:var(--danger);
+  box-shadow:0 0 0 3px rgba(255, 93, 93, 0.35);
+}
 .btn{
   background:var(--muted);
   color:var(--text);
@@ -569,6 +577,8 @@ details.group > summary .group-summary{
 .show-menu-wrap.open .show-menu{opacity:1; pointer-events:auto; transform:translateY(0);}
 .show-menu .menu-item{background:transparent; border:0; text-align:left; color:var(--text); padding:10px 12px; border-radius:10px; cursor:pointer; font:inherit;}
 .show-menu .menu-item:hover{background:#171b23}
+.show-menu .menu-item.danger{color:var(--danger);}
+.show-menu .menu-item.danger:hover{background:rgba(255,93,93,0.18);}
 
 .menu{position:relative; display:inline-flex; align-items:center;}
 .menu-btn{

--- a/server/index.js
+++ b/server/index.js
@@ -112,13 +112,12 @@ async function bootstrap(){
 
   app.delete('/api/shows/:id', asyncHandler(async (req, res)=>{
     const provider = getProvider();
-    const existing = await provider.getShow(req.params.id);
-    if(!existing){
+    const archived = await provider.deleteShow(req.params.id);
+    if(!archived){
       res.status(404).json({error: 'Show not found'});
       return;
     }
-    await provider.deleteShow(req.params.id);
-    res.status(204).end();
+    res.json(archived);
   }));
 
   app.post('/api/shows/:id/archive', asyncHandler(async (req, res)=>{


### PR DESCRIPTION
## Summary
- remove the crew selector from the show header, make the remaining fields required, and add inline validation feedback before creating a show
- expose a delete action in the show menu that archives the deleted show and flags it as deleted in the archive UI
- enforce required show fields and archive-deletion metadata on the server so deletes return the archived record with a deleted timestamp

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4733d026c832abc0411b40c54d958