### PR TITLE
Add archive statistics and trend chart

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -131,6 +131,7 @@
           <label for="archiveShowSelect">Archived show</label>
           <select id="archiveShowSelect"></select>
           <p id="archiveMeta" class="help"></p>
+          <section id="archiveStats" class="archive-stats" aria-live="polite"></section>
         </div>
         <div class="col-8">
           <div id="archiveDetails" class="archive-details"></div>
@@ -139,6 +140,32 @@
             <button id="archiveExportCsv" type="button" class="btn ghost" disabled>Export CSV</button>
             <button id="archiveExportJson" type="button" class="btn ghost" disabled>Export JSON</button>
           </div>
+        </div>
+      </div>
+      <div class="archive-analytics" aria-live="polite">
+        <div class="archive-analytics-header">
+          <h3>Archive analytics</h3>
+          <p class="help">Graph show statistics over time to spot trends.</p>
+        </div>
+        <div class="archive-analytics-controls">
+          <div class="control-group">
+            <label for="archiveStatSelect">Statistic</label>
+            <select id="archiveStatSelect">
+              <option value="entriesCount">Entries logged</option>
+              <option value="avgDelaySec">Average delay (s)</option>
+              <option value="completionRate">Completion rate (%)</option>
+              <option value="launchRate">Launch rate (%)</option>
+              <option value="abortRate">Abort rate (%)</option>
+            </select>
+          </div>
+          <div class="control-group">
+            <span class="control-label">Shows to plot</span>
+            <div id="archiveStatShowList" class="archive-show-list"></div>
+          </div>
+        </div>
+        <div class="archive-chart-wrap">
+          <canvas id="archiveStatCanvas" class="archive-chart" height="260" role="img" aria-label="Archived show statistic over time"></canvas>
+          <p id="archiveStatEmpty" class="help">Select one or more shows to render the chart.</p>
         </div>
       </div>
     </section>

--- a/public/styles.css
+++ b/public/styles.css
@@ -221,6 +221,30 @@ body.view-pilot .topbar-actions{
   backdrop-filter:blur(8px);
 }
 .archive-grid{align-items:flex-start;gap:20px;}
+.archive-stats{margin-top:16px;padding:16px;border:1px solid rgba(255,255,255,.12);border-radius:12px;background:rgba(15,18,24,.82);min-height:140px;}
+.archive-stats h3{margin:0 0 12px;font-size:16px;font-weight:600;color:var(--text);}
+.archive-stats dl{margin:0;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px 16px;}
+.archive-stats dt{margin:0 0 4px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-dim);}
+.archive-stats dd{margin:0;font-size:16px;font-weight:600;color:var(--text);}
+.archive-stats .help{margin:0;color:var(--text-dim);font-size:14px;}
+.archive-analytics{margin-top:32px;padding:20px;border:1px solid rgba(255,255,255,.12);border-radius:12px;background:rgba(12,14,18,.9);}
+.archive-analytics-header{display:flex;flex-direction:column;gap:4px;margin-bottom:16px;}
+.archive-analytics h3{margin:0;font-size:18px;font-weight:600;color:var(--text);}
+.archive-analytics-controls{display:flex;flex-wrap:wrap;gap:20px;align-items:flex-end;margin-bottom:16px;}
+.archive-analytics .control-group{display:flex;flex-direction:column;gap:6px;min-width:200px;}
+.archive-analytics .control-group select{min-width:200px;}
+.archive-analytics .control-label{font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-dim);}
+.archive-show-list{display:flex;flex-wrap:wrap;gap:8px 12px;padding:8px 12px;border:1px dashed rgba(255,255,255,.16);border-radius:10px;background:rgba(10,12,16,.78);max-height:160px;overflow:auto;}
+.archive-show-list label{display:flex;align-items:center;gap:6px;font-size:14px;color:var(--text);padding:4px 8px;border-radius:8px;background:rgba(255,255,255,.05);}
+.archive-show-list input[type="checkbox"]{accent-color:var(--primary);}
+.archive-chart-wrap{position:relative;}
+.archive-chart{width:100%;height:260px;display:block;border:1px solid rgba(255,255,255,.12);border-radius:12px;background:#fff;}
+.archive-chart-wrap .help{margin-top:12px;color:var(--text-dim);}
+@media (max-width:960px){
+  .archive-stats dl{grid-template-columns:1fr;}
+  .archive-analytics-controls{flex-direction:column;align-items:stretch;}
+  .archive-analytics .control-group{min-width:0;}
+}
 .archive-details{
   min-height:140px;
   display:flex;


### PR DESCRIPTION
## Summary
- add an archive sidebar statistics module that summarizes entries, rates, and delays for the selected show
- introduce reusable metric calculations and a canvas-based chart that graphs selected statistics across archived shows
- style the archive panel analytics area with responsive controls and chart layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4d0109794832a8fed2caeaf9c0911