### PR TITLE
Enhance archive analytics visualization

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -149,23 +149,43 @@
         </div>
         <div class="archive-analytics-controls">
           <div class="control-group">
-            <label for="archiveStatSelect">Statistic</label>
-            <select id="archiveStatSelect">
+            <label for="archiveStatSelect">Metrics</label>
+            <select id="archiveStatSelect" multiple size="5" aria-describedby="archiveMetricHelp">
               <option value="entriesCount">Entries logged</option>
               <option value="avgDelaySec">Average delay (s)</option>
               <option value="completionRate">Completion rate (%)</option>
               <option value="launchRate">Launch rate (%)</option>
               <option value="abortRate">Abort rate (%)</option>
             </select>
+            <p id="archiveMetricHelp" class="help small">Select one or more metrics to visualise together.</p>
           </div>
           <div class="control-group">
-            <span class="control-label">Shows to plot</span>
-            <div id="archiveStatShowList" class="archive-show-list"></div>
+            <span class="control-label">Date range</span>
+            <div class="date-range" role="group" aria-label="Archive date range">
+              <label class="sr-only" for="archiveShowFilterStart">Start date</label>
+              <input id="archiveShowFilterStart" type="date" />
+              <span class="date-range-sep" aria-hidden="true">→</span>
+              <label class="sr-only" for="archiveShowFilterEnd">End date</label>
+              <input id="archiveShowFilterEnd" type="date" />
+            </div>
+            <p class="help small">Filter the show list using calendar dates.</p>
+          </div>
+          <div class="control-group">
+            <label for="archiveStatShowSelect">Shows to plot</label>
+            <select id="archiveStatShowSelect" multiple size="8" aria-describedby="archiveShowHelp"></select>
+            <div class="control-actions">
+              <button id="archiveSelectAllShows" type="button" class="btn ghost small">Select all in range</button>
+              <button id="archiveClearShowSelection" type="button" class="btn ghost small">Clear</button>
+            </div>
+            <p id="archiveShowHelp" class="help small">Use Shift or Ctrl/Cmd click to choose multiple shows.</p>
+          </div>
+          <div class="control-group control-group-inline">
+            <button id="archiveLoadSample" type="button" class="btn ghost">Load sample month</button>
           </div>
         </div>
         <div class="archive-chart-wrap">
-          <canvas id="archiveStatCanvas" class="archive-chart" height="260" role="img" aria-label="Archived show statistic over time"></canvas>
-          <p id="archiveStatEmpty" class="help">Select one or more shows to render the chart.</p>
+          <canvas id="archiveStatCanvas" class="archive-chart" role="img" aria-label="Archived show statistic over time"></canvas>
+          <p id="archiveStatEmpty" class="help">Select one or more shows and metrics to render the chart.</p>
         </div>
       </div>
     </section>
@@ -375,6 +395,8 @@
 
   <div id="toast" class="toast" role="status" aria-live="polite"></div>
 
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
   <script src="./app.js" type="module"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -231,14 +231,19 @@ body.view-pilot .topbar-actions{
 .archive-analytics-header{display:flex;flex-direction:column;gap:4px;margin-bottom:16px;}
 .archive-analytics h3{margin:0;font-size:18px;font-weight:600;color:var(--text);}
 .archive-analytics-controls{display:flex;flex-wrap:wrap;gap:20px;align-items:flex-end;margin-bottom:16px;}
-.archive-analytics .control-group{display:flex;flex-direction:column;gap:6px;min-width:200px;}
-.archive-analytics .control-group select{min-width:200px;}
+.archive-analytics .control-group{display:flex;flex-direction:column;gap:6px;min-width:220px;}
+.archive-analytics .control-group select{min-width:220px;}
 .archive-analytics .control-label{font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-dim);}
-.archive-show-list{display:flex;flex-wrap:wrap;gap:8px 12px;padding:8px 12px;border:1px dashed rgba(255,255,255,.16);border-radius:10px;background:rgba(10,12,16,.78);max-height:160px;overflow:auto;}
-.archive-show-list label{display:flex;align-items:center;gap:6px;font-size:14px;color:var(--text);padding:4px 8px;border-radius:8px;background:rgba(255,255,255,.05);}
-.archive-show-list input[type="checkbox"]{accent-color:var(--primary);}
-.archive-chart-wrap{position:relative;}
-.archive-chart{width:100%;height:260px;display:block;border:1px solid rgba(255,255,255,.12);border-radius:12px;background:#fff;}
+.archive-analytics .control-group select[multiple]{min-height:180px;padding:8px;border-radius:10px;background:rgba(12,15,22,.82);border:1px solid rgba(255,255,255,.18);color:var(--text);}
+.archive-analytics .control-actions{display:flex;gap:10px;flex-wrap:wrap;}
+.control-group-inline{justify-content:flex-start;align-items:flex-end;}
+.help.small{font-size:12px;line-height:1.4;color:var(--text-dim);}
+.btn.small{padding:8px 12px;min-height:32px;font-size:13px;border-radius:10px;}
+.date-range{display:flex;align-items:center;gap:8px;flex-wrap:wrap;}
+.date-range input{min-width:140px;}
+.date-range-sep{font-size:16px;color:var(--text-dim);font-weight:600;}
+.archive-chart-wrap{position:relative;min-height:320px;}
+.archive-chart{width:100%;height:100%;min-height:300px;display:block;border:1px solid rgba(255,255,255,.12);border-radius:12px;background:#fff;}
 .archive-chart-wrap .help{margin-top:12px;color:var(--text-dim);}
 @media (max-width:960px){
   .archive-stats dl{grid-template-columns:1fr;}


### PR DESCRIPTION
## Summary
- replace the archive analytics controls with a Chart.js-powered multi-metric graph that supports animated rendering, time axes, and filtering by date range or show list
- add a sample month generator to quickly populate archive data for demos and validation
- refresh analytics styling and include the required Chart.js scripts

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4d6b2683c832ab34ac3cdd063d52a