### PR TITLE
Delay archive analytics filters until a source is chosen

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -156,7 +156,7 @@
           <div class="control-group">
             <span class="control-label">Show source</span>
             <div class="segmented-control" role="radiogroup" aria-label="Show source">
-              <button type="button" class="segmented-option is-active" data-archive-mode="range" aria-pressed="true">Calendar range</button>
+              <button type="button" class="segmented-option" data-archive-mode="range" aria-pressed="false">Calendar range</button>
               <button type="button" class="segmented-option" data-archive-mode="list" aria-pressed="false">Show list</button>
             </div>
             <p class="help small">Choose how the graph is populated with shows.</p>


### PR DESCRIPTION
## Summary
- remove the default archive show source selection
- keep the calendar range and show list controls hidden until the corresponding source is chosen
- guide users to pick a source before rendering archive analytics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d502880054832a8a467dd935a0cdcf