### PR TITLE
Improve archive show source toggling

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -972,7 +972,17 @@ function renderArchiveChartControls(){
   if(archiveSelectionPanels.length){
     archiveSelectionPanels.forEach(panel => {
       const panelMode = panel.dataset.archiveModePanel;
-      panel.hidden = !mode || panelMode !== mode;
+      const isActive = Boolean(mode) && panelMode === mode;
+      panel.hidden = !isActive;
+      panel.classList.toggle('is-active', isActive);
+      panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+      if('inert' in panel){
+        panel.inert = !isActive;
+      }else if(!isActive){
+        panel.setAttribute('aria-disabled', 'true');
+      }else{
+        panel.removeAttribute('aria-disabled');
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure the archive show source panels toggle so only the selected interface remains visible
- update accessibility attributes when switching between calendar range and list modes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5064787a0832a9c1ff0d74f7d28dc