### PR TITLE
Ensure archive day detail popover resets when inputs change

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1386,6 +1386,7 @@ function onArchiveMetricOptionClick(event){
   const normalized = chartableMetrics.filter(key => selectionSet.has(key));
   state.selectedArchiveMetrics = normalized;
   renderArchiveChartControls();
+  clearArchiveDayDetail();
   renderArchiveChart();
   if(typeof metricKey === 'string'){
     requestAnimationFrame(()=>{
@@ -1407,6 +1408,7 @@ function onArchiveShowSelectChange(){
   }
   const selected = Array.from(archiveStatShowSelect.selectedOptions || []).map(option => option.value);
   state.selectedArchiveChartShows = selected;
+  clearArchiveDayDetail();
   renderArchiveChart();
 }
 
@@ -1419,6 +1421,7 @@ function onArchiveDateFilterChange(field, value){
   }
   state.archiveChartFilters[field] = value || null;
   renderArchiveChartControls();
+  clearArchiveDayDetail();
   renderArchiveChart();
 }
 
@@ -1430,6 +1433,7 @@ function selectAllFilteredArchiveShows(){
   shows.sort((a, b)=> (getShowTimestamp(a) ?? 0) - (getShowTimestamp(b) ?? 0));
   state.selectedArchiveChartShows = shows.map(show => show.id);
   renderArchiveChartControls();
+  clearArchiveDayDetail();
   renderArchiveChart();
 }
 
@@ -1486,6 +1490,7 @@ function loadSampleArchiveMonth(){
   };
   renderArchiveSelect();
   renderArchiveChartControls();
+  clearArchiveDayDetail();
   renderArchiveChart();
   const current = getArchivedShow(state.currentArchivedShowId);
   renderArchiveStats(current);


### PR DESCRIPTION
## Summary
- clear the archive day detail popover whenever metrics, show selections, or filters change
- reset the detail popover when loading the sample archive dataset so it only appears after a chart click

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d50c840e98832a94726659c3e19feb