### PR TITLE
Revamp archive analytics selection and daily insights

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -159,7 +159,15 @@
             </select>
             <p id="archiveMetricHelp" class="help small">Select one or more metrics to visualise together.</p>
           </div>
-          <div class="control-group">
+          <div class="control-group control-group-mode">
+            <span class="control-label">Populate graph by</span>
+            <div class="mode-toggle" role="group" aria-label="Show selection mode">
+              <button id="archiveModeCalendar" type="button" class="btn toggle-btn is-active" data-archive-mode="calendar">Calendar range</button>
+              <button id="archiveModeShows" type="button" class="btn toggle-btn" data-archive-mode="shows">Show picker</button>
+            </div>
+            <p class="help small">Choose how the show list feeds the chart.</p>
+          </div>
+          <div id="archiveCalendarControls" class="control-group">
             <span class="control-label">Date range</span>
             <div class="date-range" role="group" aria-label="Archive date range">
               <label class="sr-only" for="archiveShowFilterStart">Start date</label>
@@ -170,11 +178,11 @@
             </div>
             <p class="help small">Filter the show list using calendar dates.</p>
           </div>
-          <div class="control-group">
+          <div id="archiveShowControls" class="control-group" hidden>
             <label for="archiveStatShowSelect">Shows to plot</label>
             <select id="archiveStatShowSelect" multiple size="8" aria-describedby="archiveShowHelp"></select>
             <div class="control-actions">
-              <button id="archiveSelectAllShows" type="button" class="btn ghost small">Select all in range</button>
+              <button id="archiveSelectAllShows" type="button" class="btn ghost small">Select all</button>
               <button id="archiveClearShowSelection" type="button" class="btn ghost small">Clear</button>
             </div>
             <p id="archiveShowHelp" class="help small">Use Shift or Ctrl/Cmd click to choose multiple shows.</p>
@@ -186,6 +194,15 @@
         <div class="archive-chart-wrap">
           <canvas id="archiveStatCanvas" class="archive-chart" role="img" aria-label="Archived show statistic over time"></canvas>
           <p id="archiveStatEmpty" class="help">Select one or more shows and metrics to render the chart.</p>
+          <div id="archiveDayDetail" class="archive-day-detail" hidden>
+            <div class="archive-day-detail-card" role="dialog" aria-labelledby="archiveDayDetailTitle">
+              <div class="archive-day-detail-header">
+                <h4 id="archiveDayDetailTitle">Day breakdown</h4>
+                <button id="closeArchiveDayDetail" type="button" class="btn icon-btn" aria-label="Close day breakdown">✖️</button>
+              </div>
+              <div id="archiveDayDetailContent" class="archive-day-detail-content"></div>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/public/styles.css
+++ b/public/styles.css
@@ -227,24 +227,48 @@ body.view-pilot .topbar-actions{
 .archive-stats dt{margin:0 0 4px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-dim);}
 .archive-stats dd{margin:0;font-size:16px;font-weight:600;color:var(--text);}
 .archive-stats .help{margin:0;color:var(--text-dim);font-size:14px;}
-.archive-analytics{margin-top:32px;padding:20px;border:1px solid rgba(255,255,255,.12);border-radius:12px;background:rgba(12,14,18,.9);}
+.archive-analytics{margin-top:32px;padding:24px;border:1px solid rgba(59,130,246,.28);border-radius:18px;background:linear-gradient(160deg, rgba(15,23,42,.96), rgba(8,15,28,.92));box-shadow:0 28px 60px rgba(2,6,23,.55);}
 .archive-analytics-header{display:flex;flex-direction:column;gap:4px;margin-bottom:16px;}
-.archive-analytics h3{margin:0;font-size:18px;font-weight:600;color:var(--text);}
-.archive-analytics-controls{display:flex;flex-wrap:wrap;gap:20px;align-items:flex-end;margin-bottom:16px;}
-.archive-analytics .control-group{display:flex;flex-direction:column;gap:6px;min-width:220px;}
-.archive-analytics .control-group select{min-width:220px;}
+.archive-analytics h3{margin:0;font-size:19px;font-weight:700;color:#e1eeff;text-shadow:0 0 16px rgba(59,130,246,.45);}
+.archive-analytics-controls{display:flex;flex-wrap:wrap;gap:24px;align-items:flex-end;margin-bottom:18px;}
+.archive-analytics .control-group{display:flex;flex-direction:column;gap:8px;min-width:220px;}
+.archive-analytics .control-group select{min-width:220px;background:rgba(15,23,42,.8);border:1px solid rgba(148,163,184,.28);border-radius:12px;color:var(--text);box-shadow:0 8px 20px rgba(2,6,23,.35);}
 .archive-analytics .control-label{font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-dim);}
-.archive-analytics .control-group select[multiple]{min-height:180px;padding:8px;border-radius:10px;background:rgba(12,15,22,.82);border:1px solid rgba(255,255,255,.18);color:var(--text);}
+.archive-analytics .control-group select[multiple]{min-height:200px;padding:10px;border-radius:14px;background:rgba(12,16,26,.88);border:1px solid rgba(59,130,246,.32);color:var(--text);backdrop-filter:blur(6px);}
 .archive-analytics .control-actions{display:flex;gap:10px;flex-wrap:wrap;}
+.archive-analytics .control-group-mode{min-width:260px;}
+.archive-analytics .mode-toggle{display:flex;gap:10px;flex-wrap:wrap;}
+.archive-analytics .toggle-btn{min-height:38px;padding:10px 18px;border-radius:999px;background:rgba(30,41,59,.6);border:1px solid rgba(148,163,184,.28);color:rgba(226,232,240,.78);font-size:13px;font-weight:600;letter-spacing:.02em;box-shadow:0 8px 18px rgba(2,6,23,.4);transition:background .2s ease, color .2s ease, border-color .2s ease, box-shadow .2s ease;}
+.archive-analytics .toggle-btn:hover{border-color:rgba(165,243,252,.45);color:#f8fafc;}
+.archive-analytics .toggle-btn.is-active{background:linear-gradient(135deg, rgba(59,130,246,.95), rgba(14,165,233,.9));border-color:rgba(56,189,248,.75);color:#041423;box-shadow:0 0 24px rgba(14,165,233,.45);}
+.archive-analytics .toggle-btn.is-active:hover{border-color:rgba(37,99,235,.85);}
 .control-group-inline{justify-content:flex-start;align-items:flex-end;}
 .help.small{font-size:12px;line-height:1.4;color:var(--text-dim);}
 .btn.small{padding:8px 12px;min-height:32px;font-size:13px;border-radius:10px;}
 .date-range{display:flex;align-items:center;gap:8px;flex-wrap:wrap;}
 .date-range input{min-width:140px;}
 .date-range-sep{font-size:16px;color:var(--text-dim);font-weight:600;}
-.archive-chart-wrap{position:relative;min-height:320px;}
-.archive-chart{width:100%;height:100%;min-height:300px;display:block;border:1px solid rgba(255,255,255,.12);border-radius:12px;background:#fff;}
-.archive-chart-wrap .help{margin-top:12px;color:var(--text-dim);}
+.archive-chart-wrap{position:relative;min-height:340px;}
+.archive-chart{width:100%;height:100%;min-height:320px;display:block;border:1px solid rgba(59,130,246,.45);border-radius:16px;background:radial-gradient(circle at 15% 25%, rgba(56,189,248,.22), transparent 55%),radial-gradient(circle at 80% 20%, rgba(14,165,233,.18), transparent 60%),radial-gradient(circle at 50% 80%, rgba(59,130,246,.18), transparent 58%),rgba(12,18,32,.96);box-shadow:0 32px 60px rgba(2,6,23,.6);}
+.archive-chart-wrap .help{margin-top:12px;color:rgba(203,213,225,.88);}
+.archive-day-detail{position:absolute;inset:12px 12px auto auto;display:flex;justify-content:flex-end;align-items:flex-start;pointer-events:none;z-index:5;}
+.archive-day-detail-card{width:min(460px, 100%);background:rgba(11,16,26,.94);border:1px solid rgba(56,189,248,.55);border-radius:18px;padding:18px 20px;box-shadow:0 24px 50px rgba(2,6,23,.7);backdrop-filter:blur(12px);pointer-events:auto;animation:panelIn .28s ease;}
+.archive-day-detail-header{display:flex;align-items:center;justify-content:space-between;gap:14px;margin-bottom:12px;}
+.archive-day-detail-header h4{margin:0;font-size:17px;font-weight:700;color:#e0f2ff;letter-spacing:.01em;}
+.archive-day-detail-content{display:flex;flex-direction:column;gap:12px;color:var(--text);}
+.archive-day-summary{margin:0;font-size:14px;color:rgba(226,232,240,.78);}
+.archive-day-metrics{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));}
+.archive-day-metric{padding:12px;border-radius:14px;background:rgba(37,99,235,.14);border:1px solid rgba(59,130,246,.32);box-shadow:0 10px 30px rgba(2,6,23,.45);}
+.archive-day-metric h5{margin:0 0 6px;font-size:12px;text-transform:uppercase;letter-spacing:.06em;color:rgba(186,230,253,.86);}
+.archive-day-metric .value{font-size:20px;font-weight:700;color:#f8fafc;text-shadow:0 0 12px rgba(59,130,246,.45);}
+.archive-day-metric .meta{margin:6px 0 0;font-size:12px;color:rgba(226,232,240,.7);}
+.archive-day-table{width:100%;border-collapse:collapse;background:rgba(15,23,42,.75);border:1px solid rgba(59,130,246,.28);border-radius:12px;overflow:hidden;box-shadow:0 14px 32px rgba(2,6,23,.5);}
+.archive-day-table thead th{padding:10px 12px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:rgba(148,163,184,.85);background:rgba(30,41,59,.82);}
+.archive-day-table tbody td,.archive-day-table tbody th{padding:10px 12px;border-bottom:1px solid rgba(148,163,184,.18);font-size:13px;color:#e2e8f0;}
+.archive-day-table tbody tr:last-child td,.archive-day-table tbody tr:last-child th{border-bottom:none;}
+.archive-day-table tbody tr:hover{background:rgba(59,130,246,.12);}
+.archive-day-table td.metric-cell{text-align:right;font-variant-numeric:tabular-nums;}
+.archive-day-detail[hidden]{display:none;}
 @media (max-width:960px){
   .archive-stats dl{grid-template-columns:1fr;}
   .archive-analytics-controls{flex-direction:column;align-items:stretch;}


### PR DESCRIPTION
## Summary
- add a calendar vs show picker toggle and day breakdown container to the archive analytics controls
- refresh archive chart styling for a high-contrast dark theme and surface the new detail panel
- aggregate chart data by day with richer tooltips and an interactive daily breakdown panel

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d51f5a2f38832aaea1422d48c21d3e