### PR TITLE
Add dynamic archive populate controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -160,25 +160,13 @@
             <p id="archiveMetricHelp" class="help small">Select one or more metrics to visualise together.</p>
           </div>
           <div class="control-group">
-            <span class="control-label">Date range</span>
-            <div class="date-range" role="group" aria-label="Archive date range">
-              <label class="sr-only" for="archiveShowFilterStart">Start date</label>
-              <input id="archiveShowFilterStart" type="date" />
-              <span class="date-range-sep" aria-hidden="true">→</span>
-              <label class="sr-only" for="archiveShowFilterEnd">End date</label>
-              <input id="archiveShowFilterEnd" type="date" />
+            <span class="control-label">Populate graph by</span>
+            <div id="archivePopulateBy" class="archive-populate-toggle" role="group" aria-label="Populate graph by">
+              <button type="button" class="btn ghost small is-active" data-mode="range" aria-pressed="true">Calendar range</button>
+              <button type="button" class="btn ghost small" data-mode="shows" aria-pressed="false">Show selection list</button>
             </div>
-            <p class="help small">Filter the show list using calendar dates.</p>
           </div>
-          <div class="control-group">
-            <label for="archiveStatShowSelect">Shows to plot</label>
-            <select id="archiveStatShowSelect" multiple size="8" aria-describedby="archiveShowHelp"></select>
-            <div class="control-actions">
-              <button id="archiveSelectAllShows" type="button" class="btn ghost small">Select all in range</button>
-              <button id="archiveClearShowSelection" type="button" class="btn ghost small">Clear</button>
-            </div>
-            <p id="archiveShowHelp" class="help small">Use Shift or Ctrl/Cmd click to choose multiple shows.</p>
-          </div>
+          <div id="archivePopulateTarget" class="archive-populate-target"></div>
           <div class="control-group control-group-inline">
             <button id="archiveLoadSample" type="button" class="btn ghost">Load sample month</button>
           </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -236,6 +236,9 @@ body.view-pilot .topbar-actions{
 .archive-analytics .control-label{font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-dim);}
 .archive-analytics .control-group select[multiple]{min-height:180px;padding:8px;border-radius:10px;background:rgba(12,15,22,.82);border:1px solid rgba(255,255,255,.18);color:var(--text);}
 .archive-analytics .control-actions{display:flex;gap:10px;flex-wrap:wrap;}
+.archive-populate-toggle{display:flex;gap:10px;flex-wrap:wrap;}
+.archive-populate-toggle .btn.is-active{background:var(--primary);border-color:var(--primary-2);color:#041423;}
+.archive-populate-target>.control-group{margin:0;}
 .control-group-inline{justify-content:flex-start;align-items:flex-end;}
 .help.small{font-size:12px;line-height:1.4;color:var(--text-dim);}
 .btn.small{padding:8px 12px;min-height:32px;font-size:13px;border-radius:10px;}


### PR DESCRIPTION
## Summary
- add a toggle to choose between calendar range and show selection inputs for archive analytics
- render the chosen controls dynamically and keep archive chart state in sync
- style the new populate toggle to reflect the active selection

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d524f30d14832abee06357c77f7d46