### PR TITLE
Refine archive archive popover UX

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -257,22 +257,27 @@ body.view-pilot .topbar-actions{
 .archive-chart{width:100%;height:100%;min-height:320px;display:block;border:1px solid rgba(59,130,246,.45);border-radius:16px;background:radial-gradient(circle at 15% 25%, rgba(56,189,248,.22), transparent 55%),radial-gradient(circle at 80% 20%, rgba(14,165,233,.18), transparent 60%),radial-gradient(circle at 50% 80%, rgba(59,130,246,.18), transparent 58%),rgba(12,18,32,.96);box-shadow:0 32px 60px rgba(2,6,23,.6);}
 .archive-chart-wrap .help{margin-top:12px;color:rgba(203,213,225,.88);}
 .archive-day-detail{position:absolute;inset:12px 12px auto auto;display:flex;justify-content:flex-end;align-items:flex-start;pointer-events:none;z-index:5;}
-.archive-day-detail-card{width:min(460px, 100%);background:rgba(11,16,26,.94);border:1px solid rgba(56,189,248,.55);border-radius:18px;padding:18px 20px;box-shadow:0 24px 50px rgba(2,6,23,.7);backdrop-filter:blur(12px);pointer-events:auto;animation:panelIn .28s ease;}
-.archive-day-detail-header{display:flex;align-items:center;justify-content:space-between;gap:14px;margin-bottom:12px;}
-.archive-day-detail-header h4{margin:0;font-size:17px;font-weight:700;color:#e0f2ff;letter-spacing:.01em;}
-.archive-day-detail-content{display:flex;flex-direction:column;gap:12px;color:var(--text);}
-.archive-day-summary{margin:0;font-size:14px;color:rgba(226,232,240,.78);}
-.archive-day-metrics{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));}
-.archive-day-metric{padding:12px;border-radius:14px;background:rgba(37,99,235,.14);border:1px solid rgba(59,130,246,.32);box-shadow:0 10px 30px rgba(2,6,23,.45);}
-.archive-day-metric h5{margin:0 0 6px;font-size:12px;text-transform:uppercase;letter-spacing:.06em;color:rgba(186,230,253,.86);}
-.archive-day-metric .value{font-size:20px;font-weight:700;color:#f8fafc;text-shadow:0 0 12px rgba(59,130,246,.45);}
-.archive-day-metric .meta{margin:6px 0 0;font-size:12px;color:rgba(226,232,240,.7);}
-.archive-day-table{width:100%;border-collapse:collapse;background:rgba(15,23,42,.75);border:1px solid rgba(59,130,246,.28);border-radius:12px;overflow:hidden;box-shadow:0 14px 32px rgba(2,6,23,.5);}
-.archive-day-table thead th{padding:10px 12px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:rgba(148,163,184,.85);background:rgba(30,41,59,.82);}
-.archive-day-table tbody td,.archive-day-table tbody th{padding:10px 12px;border-bottom:1px solid rgba(148,163,184,.18);font-size:13px;color:#e2e8f0;}
-.archive-day-table tbody tr:last-child td,.archive-day-table tbody tr:last-child th{border-bottom:none;}
-.archive-day-table tbody tr:hover{background:rgba(59,130,246,.12);}
-.archive-day-table td.metric-cell{text-align:right;font-variant-numeric:tabular-nums;}
+.archive-day-detail-card{width:min(320px, calc(100vw - 48px));max-height:calc(100vh - 140px);background:rgba(11,16,26,.92);border:1px solid rgba(56,189,248,.4);border-radius:14px;padding:14px 16px;box-shadow:0 18px 40px rgba(2,6,23,.55);backdrop-filter:blur(10px);pointer-events:auto;transform-origin:top right;opacity:0;transform:translateY(8px) scale(.95);transition:opacity .18s ease, transform .18s ease;overflow:auto;}
+.archive-day-detail.showing .archive-day-detail-card{opacity:1;transform:translateY(0) scale(1);}
+.archive-day-detail.closing .archive-day-detail-card{opacity:0;transform:translateY(-4px) scale(.96);}
+.archive-day-detail-header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:10px;}
+.archive-day-detail-header h4{margin:0;font-size:15px;font-weight:700;color:#e0f2ff;letter-spacing:.01em;}
+.archive-day-detail-content{display:flex;flex-direction:column;gap:10px;color:var(--text);}
+.archive-day-summary{margin:0;font-size:13px;color:rgba(226,232,240,.78);}
+.archive-day-metrics{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));}
+.archive-day-metric{padding:10px 12px;border-radius:12px;background:rgba(37,99,235,.12);border:1px solid rgba(59,130,246,.28);box-shadow:0 8px 22px rgba(2,6,23,.4);}
+.archive-day-metric h5{margin:0 0 4px;font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:rgba(186,230,253,.86);}
+.archive-day-metric .value{font-size:18px;font-weight:700;color:#f8fafc;}
+.archive-day-metric .meta{margin:4px 0 0;font-size:11px;color:rgba(226,232,240,.7);}
+.archive-day-shows{display:flex;flex-direction:column;gap:8px;}
+.archive-day-show-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:8px;}
+.archive-day-show{display:flex;flex-direction:column;gap:4px;padding:8px 10px;border-radius:10px;background:rgba(15,23,42,.72);border:1px solid rgba(59,130,246,.18);}
+.archive-day-show-name{font-size:13px;font-weight:600;color:#e2e8f0;}
+.archive-day-show-metrics{display:flex;flex-wrap:wrap;gap:4px 8px;font-size:12px;color:rgba(191,219,254,.9);}
+.archive-day-show-metrics .metric{display:flex;gap:4px;align-items:center;padding:2px 8px;border-radius:999px;background:rgba(59,130,246,.14);}
+.archive-day-show-metrics .metric-label{font-weight:600;color:rgba(191,219,254,.95);}
+.archive-day-show-metrics .metric-value{color:#f8fafc;font-variant-numeric:tabular-nums;}
+.archive-day-more{margin:0;font-size:12px;color:rgba(148,163,184,.85);}
 .archive-day-detail[hidden]{display:none;}
 @media (max-width:960px){
   .archive-stats dl{grid-template-columns:1fr;}


### PR DESCRIPTION
## Summary
- shrink the archive day detail panel and replace the data table with a concise show summary list
- add explicit entrance and exit animations so the archive day breakdown popover fades in and out smoothly
- simplify archive tooltip contents and spacing for a smaller hover card

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d545c9867c832aa093c834d1ae7866