### PR TITLE
Unify button styling with landing page

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -243,10 +243,28 @@ body.view-pilot .topbar-actions{
 .archive-analytics .control-actions{display:flex;gap:10px;flex-wrap:wrap;}
 .archive-analytics .control-group-mode{min-width:260px;}
 .archive-analytics .mode-toggle{display:flex;gap:10px;flex-wrap:wrap;}
-.archive-analytics .toggle-btn{min-height:38px;padding:10px 18px;border-radius:999px;background:rgba(30,41,59,.6);border:1px solid rgba(148,163,184,.28);color:rgba(226,232,240,.78);font-size:13px;font-weight:600;letter-spacing:.02em;box-shadow:0 8px 18px rgba(2,6,23,.4);transition:background .2s ease, color .2s ease, border-color .2s ease, box-shadow .2s ease;}
-.archive-analytics .toggle-btn:hover{border-color:rgba(165,243,252,.45);color:#f8fafc;}
-.archive-analytics .toggle-btn.is-active{background:linear-gradient(135deg, rgba(59,130,246,.95), rgba(14,165,233,.9));border-color:rgba(56,189,248,.75);color:#041423;box-shadow:0 0 24px rgba(14,165,233,.45);}
-.archive-analytics .toggle-btn.is-active:hover{border-color:rgba(37,99,235,.85);}
+.archive-analytics .toggle-btn{
+  min-height:38px;
+  padding:10px 18px;
+  border-radius:999px;
+  font-size:13px;
+  font-weight:600;
+  letter-spacing:.02em;
+  --btn-bg:rgba(17, 20, 28, 0.9);
+  --btn-border:rgba(86, 108, 164, 0.45);
+  --btn-color:rgba(226, 232, 240, 0.85);
+  --btn-hover-bg:#22c55e;
+  --btn-hover-border:#16a34a;
+  --btn-hover-color:#041423;
+}
+.archive-analytics .toggle-btn.is-active{
+  --btn-bg:#22c55e;
+  --btn-border:#16a34a;
+  --btn-color:#041423;
+  --btn-hover-bg:#16a34a;
+  --btn-hover-border:#15803d;
+  --btn-hover-color:#041423;
+}
 .control-group-inline{justify-content:flex-start;align-items:flex-end;}
 .help.small{font-size:12px;line-height:1.4;color:var(--text-dim);}
 .btn.small{padding:8px 12px;min-height:32px;font-size:13px;border-radius:10px;}
@@ -537,58 +555,72 @@ input.is-invalid:focus, select.is-invalid:focus, textarea.is-invalid:focus{
   box-shadow:0 0 0 3px rgba(255, 93, 93, 0.35);
 }
 .btn{
-  background:var(--muted);
-  color:var(--text);
-  border:1px solid var(--border);
+  --btn-bg:rgba(17, 20, 28, 0.96);
+  --btn-border:rgba(86, 108, 164, 0.45);
+  --btn-color:var(--text);
+  --btn-hover-bg:#2563eb;
+  --btn-hover-border:#1d4ed8;
+  --btn-hover-color:#f8faff;
+  background:var(--btn-bg);
+  color:var(--btn-color);
+  border:1px solid var(--btn-border);
   border-radius:12px;
   padding:12px 14px;
   min-height:var(--tap-min);
   font-weight:700;
   cursor:pointer;
-  transition:.15s transform, .15s background, .15s border-color;
+  transition:background-color .35s ease, border-color .35s ease,
+    color .35s ease, opacity .35s ease, box-shadow .35s ease,
+    transform .15s ease;
   user-select:none;
   -webkit-tap-highlight-color:transparent;
 }
-.btn:hover{background:#232733}
+.btn:hover,
+.btn:focus-visible{
+  background:var(--btn-hover-bg);
+  border-color:var(--btn-hover-border);
+  color:var(--btn-hover-color);
+  box-shadow:0 16px 34px rgba(0, 0, 0, 0.3);
+}
 .btn:active{transform:translateY(1px)}
-.btn.primary{background:var(--primary); border-color:var(--primary-2); color:#041423}
+.btn.primary{
+  --btn-hover-bg:#2563eb;
+  --btn-hover-border:#1d4ed8;
+  --btn-hover-color:#f8faff;
+}
+.btn.ghost{
+  --btn-hover-bg:#f97316;
+  --btn-hover-border:#ea580c;
+  --btn-hover-color:#fffaf5;
+}
+.btn.icon-btn{
+  --btn-hover-bg:#ef4444;
+  --btn-hover-border:#dc2626;
+  --btn-hover-color:#fff5f5;
+}
 .btn.role-btn{
   min-width:160px;
   font-size:18px;
   padding:18px 26px;
-  background:rgba(17, 20, 28, 0.96);
-  border-color:rgba(86, 108, 164, 0.45);
-  color:var(--text);
-  transition:background-color .2s ease, border-color .2s ease, color .2s ease,
-    opacity .2s ease, transform .15s ease;
+  --btn-hover-bg:#2563eb;
+  --btn-hover-border:#1d4ed8;
+  --btn-hover-color:#f8faff;
 }
-
-.btn.role-btn:hover,
-.btn.role-btn:focus-visible{
-  opacity:0.92;
+#chooseLead.btn.role-btn{
+  --btn-hover-bg:#2563eb;
+  --btn-hover-border:#1d4ed8;
+  --btn-hover-color:#f8faff;
 }
-
-#chooseLead.btn.role-btn:hover,
-#chooseLead.btn.role-btn:focus-visible{
-  background-color:#2563eb;
-  border-color:#1d4ed8;
-  color:#f8faff;
+#choosePilot.btn.role-btn{
+  --btn-hover-bg:#16a34a;
+  --btn-hover-border:#15803d;
+  --btn-hover-color:#f1fff7;
 }
-
-#choosePilot.btn.role-btn:hover,
-#choosePilot.btn.role-btn:focus-visible{
-  background-color:#16a34a;
-  border-color:#15803d;
-  color:#f1fff7;
+#chooseArchive.btn.role-btn{
+  --btn-hover-bg:#7c3aed;
+  --btn-hover-border:#6d28d9;
+  --btn-hover-color:#f5f1ff;
 }
-
-#chooseArchive.btn.role-btn:hover,
-#chooseArchive.btn.role-btn:focus-visible{
-  background-color:#7c3aed;
-  border-color:#6d28d9;
-  color:#f5f1ff;
-}
-.btn.ghost{background:transparent}
 .btn.icon-btn{width:var(--tap-min); height:var(--tap-min); display:inline-grid; place-items:center; border-radius:12px;}
 .hamburger-btn{padding:0;}
 .hamburger-icon{display:inline-flex; flex-direction:column; gap:4px; align-items:center; justify-content:center;}


### PR DESCRIPTION
## Summary
- restyle the shared `.btn` base to match the landing page look and add smooth fade transitions
- provide colorful hover accents for primary, ghost, icon, role, and toggle buttons using CSS custom properties
- align archive toggle buttons with the unified styling while preserving their layout-specific sizing

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d708eae1b0832ab20e823fe3173835