### PR TITLE
Align header layout and gate admin settings by role

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -41,6 +41,7 @@
         <select id="regRole" name="role" required>
           <option value="pilot">Pilot</option>
           <option value="stagehand">Stagehand</option>
+          <option value="admin">Admin (superuser)</option>
         </select>
         <div class="grid auth-grid">
           <div class="col-6">
@@ -98,7 +99,7 @@
         <section class="config-section grid" data-config-section="users" aria-hidden="true">
           <div class="col-12">
             <h3>User directory</h3>
-            <p class="help">Manage pilots and stagehands. These accounts power the crew &amp; lead lists.</p>
+            <p class="help">Manage pilots, stagehands, and admins. These accounts power the crew &amp; lead lists.</p>
           </div>
           <div class="col-12">
             <div id="userList" class="user-list" role="list"></div>
@@ -120,6 +121,7 @@
                 <select id="userRole">
                   <option value="pilot">Pilot</option>
                   <option value="stagehand">Stagehand</option>
+                  <option value="admin">Admin (superuser)</option>
                 </select>
               </div>
               <div class="col-6">
@@ -183,7 +185,7 @@
     <div id="appMain" class="app-main">
       <div class="topbar" role="banner">
         <div class="toolbar topbar-toolbar">
-          <div class="topbar-actions">
+          <div class="topbar-left">
             <button id="configBtn" class="btn icon-btn hamburger-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings">
               <span class="hamburger-icon" aria-hidden="true">
                 <span></span>
@@ -193,17 +195,19 @@
               <span class="sr-only">Open settings</span>
             </button>
             <button id="roleHome" class="btn ghost" type="button">← Choose workspace</button>
+            <img src="./assets/Sphere%20Logo_RGB%20_White.png" alt="Sphere" class="app-logo" />
+          </div>
+          <div class="topbar-right">
+            <div class="topbar-title">
+              <span id="viewBadge" class="view-badge">Lead workspace</span>
+              <div class="title-stack">
+                <h1 class="app-title">Flight Log Form</h1>
+                <span class="title-sub">Tracking <span id="appTitle">Drone</span> activity</span>
+              </div>
+            </div>
             <div class="topbar-user" aria-live="polite">
               <span id="currentUserLabel" class="user-label"></span>
               <button id="logoutBtn" class="btn ghost small" type="button">Sign out</button>
-            </div>
-          </div>
-          <img src="./assets/Sphere%20Logo_RGB%20_White.png" alt="Sphere" class="app-logo" />
-          <div class="topbar-title">
-            <span id="viewBadge" class="view-badge">Lead workspace</span>
-            <div class="title-stack">
-              <h1 class="app-title">Flight Log Form</h1>
-              <span class="title-sub">Tracking <span id="appTitle">Drone</span> activity</span>
             </div>
           </div>
         </div>
@@ -211,6 +215,7 @@
 
       <div class="container" role="main">
     <section id="landingView" class="panel landing-panel view-landing-only" aria-labelledby="landingTitle">
+      <p id="landingWelcome" class="landing-welcome" hidden></p>
       <h2 id="landingTitle">Choose workspace</h2>
       <p class="lead">Select the role you need for this session.</p>
       <div class="role-options">

--- a/public/styles.css
+++ b/public/styles.css
@@ -116,7 +116,7 @@ body.view-archive .view-archive-only{display:block !important}
 .auth-grid{display:grid;gap:12px;grid-template-columns:repeat(2, minmax(0,1fr));}
 .auth-message{min-height:22px;color:var(--danger);font-size:13px;margin-top:6px;}
 .auth-submit{margin-top:6px;}
-.topbar-user{display:flex;align-items:center;gap:8px;margin-left:8px;}
+.topbar-user{display:flex;align-items:center;justify-content:flex-end;gap:8px;min-width:0;visibility:hidden;}
 .topbar-user .btn.small{white-space:nowrap;}
 .user-label{font-size:13px;color:rgba(226,232,240,.72);font-weight:600;}
 .btn.danger{
@@ -235,43 +235,46 @@ body.menu-open .app-main{transform:translateX(calc(min(var(--drawer-width), 92vw
   border-bottom:1px solid var(--border);
 }
 .topbar-toolbar{
-  display:grid;
-  grid-template-columns:auto 1fr auto;
-  grid-template-areas:"actions title logo";
+  display:flex;
   align-items:center;
+  justify-content:space-between;
   gap:16px;
   min-height:60px;
   width:100%;
+  flex-wrap:wrap;
 }
-.topbar-actions{
-  grid-area:actions;
+.topbar-left{
   display:flex;
   align-items:center;
-  gap:10px;
-  justify-self:start;
+  gap:12px;
+  flex:1 1 260px;
+  min-width:0;
+  flex-wrap:wrap;
 }
-body.view-lead .topbar-actions,
-body.view-pilot .topbar-actions{
-  justify-self:start;
+.topbar-right{
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+  gap:20px;
+  flex:1 1 320px;
+  min-width:0;
+  flex-wrap:wrap;
 }
 .topbar-title{
-  grid-area:title;
   margin-left:0;
   display:flex;
   flex-direction:column;
   align-items:flex-end;
   gap:4px;
   text-align:right;
-  justify-self:end;
+  min-width:0;
 }
 .app-logo{
-  grid-area:logo;
   display:block;
   height:26px;
   width:auto;
   max-width:150px;
   filter:drop-shadow(0 8px 16px rgba(0,0,0,.45));
-  justify-self:end;
 }
 .title-stack{display:flex;flex-direction:column;align-items:flex-end;gap:4px;}
 .topbar-title .view-badge{align-self:flex-end;}
@@ -280,19 +283,29 @@ body.view-pilot .topbar-actions{
 @media (max-width:720px){
   .topbar{padding:10px 16px;}
   .topbar-toolbar{
-    grid-template-columns:auto 1fr;
-    grid-template-areas:
-      "actions logo"
-      "title title";
-    gap:10px;
-    min-height:0;
+    flex-direction:column;
+    align-items:stretch;
+    gap:12px;
   }
-  .topbar-actions{
+  .topbar-left,
+  .topbar-right{
     width:100%;
-    gap:8px;
+    flex:1 1 auto;
+  }
+  .topbar-left{
+    justify-content:space-between;
+    gap:10px;
+  }
+  .topbar-right{
+    flex-direction:column;
+    align-items:flex-start;
+    gap:12px;
+  }
+  .topbar-user{
+    width:100%;
+    justify-content:flex-start;
   }
   .topbar-title{
-    justify-self:stretch;
     align-items:flex-start;
     text-align:left;
     width:100%;
@@ -314,6 +327,13 @@ body.view-pilot .topbar-actions{
   position:relative;
   animation:panelIn .45s ease;
   transition:transform .25s ease, box-shadow .25s ease;
+}
+.landing-welcome{
+  margin:0 0 12px;
+  font-size:20px;
+  font-weight:700;
+  color:#e1eeff;
+  text-shadow:0 0 12px rgba(59,130,246,.3);
 }
 .landing-panel{
   background:rgba(22,24,29,.76);

--- a/server/storage/postgresProvider.js
+++ b/server/storage/postgresProvider.js
@@ -9,7 +9,8 @@ const DEFAULT_USERS = [
   {email: 'Alexander.Brodnik@thesphere.com', role: 'pilot', password: 'admin'},
   {email: 'Robert.Ontell@thesphere.com', role: 'pilot', password: 'admin'},
   {email: 'Cleo.Kelley@thesphere.com', role: 'stagehand', password: 'admin'},
-  {email: 'Bret.Tuttle@thesphere.com', role: 'stagehand', password: 'admin'}
+  {email: 'Bret.Tuttle@thesphere.com', role: 'stagehand', password: 'admin'},
+  {email: 'Admin.Superuser@thesphere.com', role: 'admin', password: 'admin'}
 ];
 
 const PASSWORD_ITERATIONS = 120_000;
@@ -1094,7 +1095,13 @@ class PostgresProvider {
 
   _normalizeUserRole(role){
     const value = typeof role === 'string' ? role.trim().toLowerCase() : '';
-    return value === 'pilot' ? 'pilot' : 'stagehand';
+    if(value === 'pilot'){
+      return 'pilot';
+    }
+    if(value === 'admin'){
+      return 'admin';
+    }
+    return 'stagehand';
   }
 
   _assertSphereEmail(email){


### PR DESCRIPTION
## Summary
- realign the header toolbar so the hamburger lives on the far left and the title with sign-out sit on the far right across the full width
- add a landing view welcome message that greets the signed-in user by first name
- introduce an Admin (superuser) role, seed a default admin account, and hide the admin settings tab for users without that role

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8248f0e88832ab93fd5c4afef05dc