### PR TITLE
Tighten header spacing

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -231,17 +231,18 @@ body.menu-open .app-main{transform:translateX(calc(min(var(--drawer-width), 92vw
   z-index:50;
   background:linear-gradient(to bottom, rgba(14,15,18,.95), rgba(14,15,18,.85) 60%, transparent);
   backdrop-filter:saturate(1.2) blur(8px);
-  padding:10px 20px;
+  padding:8px 20px;
   border-bottom:1px solid var(--border);
 }
 .topbar-toolbar{
   display:flex;
+  flex-direction:row;
   align-items:center;
   justify-content:space-between;
   gap:16px;
-  min-height:60px;
+  min-height:48px;
   width:100%;
-  flex-wrap:wrap;
+  flex-wrap:nowrap;
 }
 .topbar-left{
   display:flex;


### PR DESCRIPTION
## Summary
- force the topbar toolbar to lay out horizontally and prevent wrapping so header content no longer stacks in the center
- reduce vertical padding and minimum height so the header occupies less vertical space

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddcb302c34832a8913f8ba8e41df21