### PR TITLE
Relocate topbar hamburger button to leading edge

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -81,15 +81,15 @@
     <div id="appMain" class="app-main">
       <div class="topbar" role="banner">
         <div class="toolbar topbar-toolbar">
+          <button id="configBtn" class="btn icon-btn hamburger-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings">
+            <span class="hamburger-icon" aria-hidden="true">
+              <span></span>
+              <span></span>
+              <span></span>
+            </span>
+            <span class="sr-only">Open settings</span>
+          </button>
           <div class="topbar-actions">
-            <button id="configBtn" class="btn icon-btn hamburger-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings">
-              <span class="hamburger-icon" aria-hidden="true">
-                <span></span>
-                <span></span>
-                <span></span>
-              </span>
-              <span class="sr-only">Open settings</span>
-            </button>
             <button id="roleHome" class="btn ghost" type="button">← Choose workspace</button>
           </div>
           <img src="./assets/Sphere%20Logo_RGB%20_White.png" alt="Sphere" class="app-logo" />

--- a/public/styles.css
+++ b/public/styles.css
@@ -136,12 +136,16 @@ body.menu-open .app-main{transform:translateX(calc(min(var(--drawer-width), 92vw
 }
 .topbar-toolbar{
   display:grid;
-  grid-template-columns:auto 1fr auto;
-  grid-template-areas:"actions title logo";
+  grid-template-columns:auto auto 1fr auto;
+  grid-template-areas:"menu actions title logo";
   align-items:center;
   gap:16px;
   min-height:60px;
   width:100%;
+}
+.topbar-toolbar #configBtn{
+  grid-area:menu;
+  justify-self:start;
 }
 .topbar-actions{
   grid-area:actions;
@@ -182,14 +186,17 @@ body.view-pilot .topbar-actions{
   .topbar-toolbar{
     grid-template-columns:auto 1fr;
     grid-template-areas:
-      "actions logo"
+      "menu logo"
+      "actions actions"
       "title title";
     gap:10px;
     min-height:0;
   }
+  .topbar-toolbar #configBtn{justify-self:start;}
   .topbar-actions{
     width:100%;
     gap:8px;
+    justify-self:stretch;
   }
   .topbar-title{
     justify-self:stretch;


### PR DESCRIPTION
## Summary
- move the settings hamburger button outside the shared action group so it anchors to the left edge of the top bar
- update desktop and mobile grid layouts to preserve alignment after repositioning the button

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69028d9cad60832aa9531678539f5d80