### PR TITLE
Align top toolbar layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -80,7 +80,7 @@
 
     <div id="appMain" class="app-main">
       <div class="topbar" role="banner">
-        <div class="toolbar topbar-toolbar">
+        <div class="topbar-toolbar">
           <button id="configBtn" class="btn icon-btn hamburger-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Open settings">
             <span class="hamburger-icon" aria-hidden="true">
               <span></span>

--- a/public/styles.css
+++ b/public/styles.css
@@ -137,7 +137,7 @@ body.menu-open .app-main{transform:translateX(calc(min(var(--drawer-width), 92vw
 .topbar-toolbar{
   display:grid;
   grid-template-columns:auto auto 1fr auto;
-  grid-template-areas:"menu actions title logo";
+  grid-template-areas:"menu actions logo title";
   align-items:center;
   gap:16px;
   min-height:60px;
@@ -160,7 +160,7 @@ body.view-pilot .topbar-actions{
 }
 .topbar-title{
   grid-area:title;
-  margin-left:0;
+  margin-left:auto;
   display:flex;
   flex-direction:column;
   align-items:flex-end;
@@ -203,6 +203,7 @@ body.view-pilot .topbar-actions{
     align-items:flex-start;
     text-align:left;
     width:100%;
+    margin-left:0;
   }
   .title-stack{align-items:flex-start;}
 }
@@ -781,6 +782,26 @@ summary::-webkit-details-marker{display:none}
   display:flex;
   flex-direction:column;
   gap:8px;
+}
+.topbar-toolbar{
+  display:grid;
+  grid-template-columns:auto auto 1fr auto;
+  grid-template-areas:"menu actions logo title";
+  align-items:center;
+  gap:16px;
+  min-height:60px;
+  width:100%;
+}
+@media (max-width:720px){
+  .topbar-toolbar{
+    grid-template-columns:auto 1fr;
+    grid-template-areas:
+      "menu logo"
+      "actions actions"
+      "title title";
+    gap:10px;
+    min-height:0;
+  }
 }
 .panel-header{display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:12px; flex-wrap:wrap}
 .panel-actions{display:flex; gap:10px; align-items:center; flex-wrap:wrap}


### PR DESCRIPTION
## Summary
- remove the generic toolbar class from the top toolbar wrapper so the grid styles can apply
- restore the top toolbar grid after the generic toolbar rule and swap the grid order so the title area renders last
- keep the mobile breakpoint layout intact while ensuring the title stack aligns flush right on wide screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903d896b1e8832a903e29f5d175495e