### PR TITLE
Add webhook message payload mapping for Coda integration

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3726,6 +3726,15 @@ function buildWebhookRow(show = {}, entry = {}){
   };
 }
 
+function buildWebhookMessage(row = {}){
+  const payload = {};
+  EXPORT_COLUMNS.forEach(column => {
+    const value = row[column];
+    payload[column] = value === undefined || value === null ? '' : value;
+  });
+  return payload;
+}
+
 function buildSampleWebhookRow(){
   return {
     showId: 'sample-show',
@@ -4011,6 +4020,8 @@ function updateWebhookPreview(){
   if(emptyRow){
     row = buildSampleWebhookRow();
   }
+  const message = buildWebhookMessage(row);
+  const messageJson = JSON.stringify(message, null, 2);
   const headerCells = EXPORT_COLUMNS.map(column=>`<th>${escapeHtml(column)}</th>`).join('');
   const rowCells = EXPORT_COLUMNS.map(column=>`<td>${escapeHtml(row[column] ?? '')}</td>`).join('');
   const statusMessage = !enabled
@@ -4023,6 +4034,10 @@ function updateWebhookPreview(){
         <thead><tr>${headerCells}</tr></thead>
         <tbody><tr>${rowCells}</tr></tbody>
       </table>
+    </div>
+    <div class="webhook-json-wrap">
+      <div class="webhook-json-label">JSON payload (.message)</div>
+      <pre class="webhook-json"><code>${escapeHtml(messageJson)}</code></pre>
     </div>
   `;
   webhookPreview.classList.toggle('is-disabled', !enabled || !url);

--- a/public/styles.css
+++ b/public/styles.css
@@ -1014,3 +1014,18 @@ summary::-webkit-details-marker{display:none}
 .webhook-table tr:last-child td{border-bottom:none}
 .webhook-table td:last-child,.webhook-table th:last-child{border-right:none}
 .webhook-table tbody tr:hover{background:rgba(74,163,255,.08)}
+.webhook-json-wrap{display:flex; flex-direction:column; gap:6px}
+.webhook-json-label{text-transform:uppercase; letter-spacing:.08em; font-size:11px; color:var(--text-dim)}
+.webhook-json{
+  margin:0;
+  padding:12px;
+  background:rgba(15,18,24,.92);
+  border:1px solid rgba(255,255,255,.06);
+  border-radius:10px;
+  font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size:12px;
+  line-height:1.45;
+  max-height:220px;
+  overflow:auto
+}
+.webhook-json code{color:inherit}

--- a/scripts/simulate-webhook.js
+++ b/scripts/simulate-webhook.js
@@ -1,5 +1,11 @@
 const http = require('http');
-const { setWebhookConfig, dispatchEntryEvent, EXPORT_COLUMNS, buildTableRow } = require('../server/webhookDispatcher');
+const {
+  setWebhookConfig,
+  dispatchEntryEvent,
+  EXPORT_COLUMNS,
+  buildTableRow,
+  buildMessagePayload
+} = require('../server/webhookDispatcher');
 
 async function run(){
   const port = 4101;
@@ -73,6 +79,12 @@ async function run(){
   const matches = JSON.stringify(actualRow) === JSON.stringify(expectedRow);
   if(!matches){
     throw new Error('Webhook table row does not match CSV export order');
+  }
+
+  const expectedMessage = buildMessagePayload(expectedRowMap);
+  const actualMessage = capturedPayload.message || {};
+  if(JSON.stringify(actualMessage) !== JSON.stringify(expectedMessage)){
+    throw new Error('Webhook message payload does not mirror expected column mapping');
   }
 
   if(capturedPayload.csv && capturedPayload.csv.header){

--- a/server/webhookDispatcher.js
+++ b/server/webhookDispatcher.js
@@ -101,6 +101,14 @@ function buildTableRow(show = {}, entry = {}){
   };
 }
 
+function buildMessagePayload(rowObject = {}){
+  return EXPORT_COLUMNS.reduce((acc, column)=>{
+    const value = rowObject[column];
+    acc[column] = value === undefined || value === null ? '' : value;
+    return acc;
+  }, {});
+}
+
 function csvEscape(value){
   const str = value === null || value === undefined ? '' : String(value);
   if(str.includes('"') || str.includes(',') || /[\n\r]/.test(str)){
@@ -118,6 +126,7 @@ async function dispatchEntryEvent(event, show, entry){
     return {skipped: true};
   }
   const rowObject = buildTableRow(show, entry);
+  const message = buildMessagePayload(rowObject);
   const payload = {
     event,
     schemaVersion: 2,
@@ -134,6 +143,7 @@ async function dispatchEntryEvent(event, show, entry){
       header: EXPORT_COLUMNS,
       row: buildCsvRow(rowObject)
     },
+    message,
     show: {
       id: show?.id || '',
       label: show?.label || '',
@@ -180,5 +190,6 @@ module.exports = {
   dispatchEntryEvent,
   buildTableRow,
   buildCsvRow,
+  buildMessagePayload,
   EXPORT_COLUMNS
 };


### PR DESCRIPTION
## Summary
- add a `message` object to webhook payloads so column values are easy to consume in automations
- surface the JSON payload preview inside the webhook configuration modal for quick reference
- update the webhook simulator and styles to cover the new payload structure

## Testing
- npm run simulate:webhook
- npm test

------
https://chatgpt.com/codex/tasks/task_b_690400dc634483249b1f3e02cd7688a0