### PR TITLE
Add webhook show replay and simulation controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -64,6 +64,8 @@
             </label>
             <p class="help">Send each recorded entry to an external endpoint using the same columns as the CSV export.</p>
             <button id="webhookConfigure" type="button" class="btn ghost" hidden>Config webhook</button>
+            <button id="webhookSimulateMonth" type="button" class="btn ghost">Simulate month delivery</button>
+            <p class="help small">Replay the most recent month of shows to the webhook for validation.</p>
           </fieldset>
         </section>
         <div class="config-actions row">

--- a/public/styles.css
+++ b/public/styles.css
@@ -989,6 +989,7 @@ summary::-webkit-details-marker{display:none}
 
 #configMessage{min-height:20px}
 #webhookConfigure{margin-top:12px;min-width:180px}
+#webhookSimulateMonth{margin-top:12px;min-width:220px}
 
 .webhook-preview{
   margin-top:12px;


### PR DESCRIPTION
## Summary
- dispatch show-level webhook payloads when a show is archived or deleted
- add an admin simulation button and API to replay a month of shows to the webhook
- refactor the webhook dispatcher to share request helpers across entry and show events

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_69040b9e3be083248bf242d42c9a6cde