### PR TITLE
Ensure login screen displays by default for unauthenticated sessions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -114,7 +114,7 @@ const state = {
   unitLabel: 'Drone',
   shows: [],
   currentShowId: null,
-  currentView: 'landing',
+  currentView: 'login',
   editingEntryRef: null,
   serverHost: '10.241.211.120',
   serverPort: 3000,

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <link rel="stylesheet" href="./styles.css" />
 </head>
-<body>
+<body class="view-login">
   <div id="appShell" class="app-shell">
     <aside id="configPanel" class="config" role="dialog" aria-modal="true" aria-labelledby="configTitle" aria-hidden="true">
       <div class="toolbar config-header">


### PR DESCRIPTION
## Summary
- default the application shell to the login view before scripts run
- align the initial state tracking with the login default so the UI classes match

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_69068dea2d808324b534d7326e691afd