### PR TITLE
Enforce default password rotation on initial accounts

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -36,6 +36,9 @@ body{
 body.view-landing{
   background:var(--bg) url("./assets/woz_4d_m.jpg") center/cover no-repeat;
 }
+body.view-login{
+  background:var(--bg) url("./assets/woz_4d_m.jpg") center/cover no-repeat;
+}
 h1,h2,h3{margin:0 0 8px}
 h1{font-size:22px}
 h2{font-size:18px;color:var(--text-dim)}
@@ -754,6 +757,8 @@ input.is-invalid:focus, select.is-invalid:focus, textarea.is-invalid:focus{
 .hidden{display:none !important}
 .error{color:#ff9b9b; font-size:12px; margin-top:6px}
 .help{color:var(--text-dim); font-size:12px}
+.help.error{color:var(--danger);font-weight:600;}
+.help.warn{color:var(--warn);font-weight:600;}
 
 .details.group{background:var(--panel); border:1px solid var(--border); border-radius:var(--radius); margin-top:12px; overflow:hidden}
 

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -89,13 +89,13 @@ function createUserRouter(){
 
   router.post('/:id/password', async (req, res, next)=>{
     try{
-      const {password} = req.body || {};
+      const {password, requirePasswordChange} = req.body || {};
       if(typeof password !== 'string' || password.length < 8){
         const err = new Error('Password must be at least 8 characters.');
         err.status = 400;
         throw err;
       }
-      const user = await setUserPassword(req.params.id, password);
+      const user = await setUserPassword(req.params.id, password, {requireChange: Boolean(requirePasswordChange)});
       res.json({user});
     }catch(err){
       next(err);

--- a/server/auth/password.js
+++ b/server/auth/password.js
@@ -4,8 +4,14 @@ const DEFAULT_ROUNDS = Number.isFinite(Number(process.env.BCRYPT_ROUNDS))
   ? Math.max(10, Number(process.env.BCRYPT_ROUNDS))
   : 12;
 
-async function hashPassword(password){
-  if(typeof password !== 'string' || password.length < 8){
+async function hashPassword(password, options = {}){
+  const opts = options || {};
+  if(typeof password !== 'string' || password.length === 0){
+    const err = new Error('Password is required.');
+    err.status = 400;
+    throw err;
+  }
+  if(!opts.allowShort && password.length < 8){
     const err = new Error('Password must be at least 8 characters.');
     err.status = 400;
     throw err;

--- a/server/auth/userSeeder.js
+++ b/server/auth/userSeeder.js
@@ -14,7 +14,8 @@ const DEFAULT_USERS = [
 
 async function seedDefaultUsers({defaultPassword} = {}){
   const provider = getProvider();
-  const passwordHash = defaultPassword ? await hashPassword(defaultPassword) : null;
+  const passwordHash = defaultPassword ? await hashPassword(defaultPassword, {allowShort: true}) : null;
+  const requireChange = Boolean(passwordHash);
   for(const user of DEFAULT_USERS){
     const existing = await provider.getUserByEmail(user.email);
     if(existing){
@@ -25,7 +26,7 @@ async function seedDefaultUsers({defaultPassword} = {}){
         await provider.updateUser(existing.id, {roles: mergedRoles});
       }
       if(passwordHash && !existing.passwordHash){
-        await provider.setUserPassword(existing.id, passwordHash);
+        await provider.setUserPassword(existing.id, passwordHash, {requireChange});
       }
       continue;
     }
@@ -34,7 +35,8 @@ async function seedDefaultUsers({defaultPassword} = {}){
       email: user.email,
       passwordHash,
       roles: user.roles,
-      isActive: true
+      isActive: true,
+      mustChangePassword: requireChange
     });
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -21,7 +21,7 @@ async function bootstrap(){
   let boundHost = envHost || configuredHost;
   let serverInstance = null;
   await initProvider(config);
-  const defaultSeedPassword = process.env.MONKEY_TRACKER_SEED_PASSWORD || process.env.SEED_USER_PASSWORD || 'SphereOps!2024';
+  const defaultSeedPassword = process.env.MONKEY_TRACKER_SEED_PASSWORD || process.env.SEED_USER_PASSWORD || 'sphere';
   await seedDefaultUsers({defaultPassword: defaultSeedPassword});
   await setWebhookConfig(config.webhook);
 


### PR DESCRIPTION
## Summary
- seed initial accounts with the default "sphere" password while flagging them to require a password change
- store and propagate the must-change-password state across the SQL.js and Postgres providers and expose it through the auth APIs
- prompt users with default credentials to update their password on login, improve login error toasts, and apply the workspace background to the login view

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_69069218e0248324aa149872ffd4e77e