### PR TITLE
Ensure API requests send session cookies

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4744,6 +4744,9 @@ function toNumber(value){
 
 async function apiRequest(url, options){
   const opts = options || {};
+  if(!Object.prototype.hasOwnProperty.call(opts, 'credentials')){
+    opts.credentials = 'include';
+  }
   if(opts.body && typeof opts.body !== 'string'){
     opts.body = JSON.stringify(opts.body);
   }


### PR DESCRIPTION
## Summary
- ensure all apiRequest calls include credentials so session cookies persist
- preserve ability for callers to override credentials when necessary

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_69069733d3f08324a25a4ec01c1701ca