### PR TITLE
Fix default account password seeding

### DIFF
--- a/server/auth/userSeeder.js
+++ b/server/auth/userSeeder.js
@@ -25,7 +25,8 @@ async function seedDefaultUsers({defaultPassword} = {}){
       if(needsRoleUpdate){
         await provider.updateUser(existing.id, {roles: mergedRoles});
       }
-      if(passwordHash && !existing.passwordHash){
+      const shouldResetPassword = Boolean(passwordHash) && (!existing.passwordHash || existing.mustChangePassword);
+      if(shouldResetPassword){
         await provider.setUserPassword(existing.id, passwordHash, {requireChange});
       }
       continue;

--- a/server/index.js
+++ b/server/index.js
@@ -21,7 +21,7 @@ async function bootstrap(){
   let boundHost = envHost || configuredHost;
   let serverInstance = null;
   await initProvider(config);
-  const defaultSeedPassword = process.env.MONKEY_TRACKER_SEED_PASSWORD || process.env.SEED_USER_PASSWORD || 'sphere';
+  const defaultSeedPassword = process.env.MONKEY_TRACKER_SEED_PASSWORD || process.env.SEED_USER_PASSWORD || 'sphereops!2024';
   await seedDefaultUsers({defaultPassword: defaultSeedPassword});
   await setWebhookConfig(config.webhook);
 


### PR DESCRIPTION
## Summary
- update the default seed password to `sphereops!2024`
- reset seeded account passwords when they still require a change so they pick up the new default

## Testing
- manual curl login with `isaiah.mincher@thesphere.com` using the updated password
- manual curl request to `/api/session` using the issued session cookie


------
https://chatgpt.com/codex/tasks/task_b_69069b5c4d58832486c2d47a3ba95443