### PR TITLE
Update archive operator filtering and UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -167,7 +167,15 @@
           <div id="archiveModeControls" class="control-group"></div>
         </div>
         <div class="archive-chart-wrap">
-          <canvas id="archiveStatCanvas" class="archive-chart" role="img" aria-label="Archived show statistic over time"></canvas>
+          <div class="archive-chart-panel">
+            <div class="archive-chart-filter control-group control-group-inline">
+              <label for="archiveOperatorFilter">Operator</label>
+              <select id="archiveOperatorFilter">
+                <option value="">All operators</option>
+              </select>
+            </div>
+            <canvas id="archiveStatCanvas" class="archive-chart" role="img" aria-label="Archived show statistic over time"></canvas>
+          </div>
           <p id="archiveStatEmpty" class="help">Select one or more shows and metrics to render the chart.</p>
           <div id="archiveDayDetail" class="archive-day-detail" hidden>
             <div class="archive-day-detail-card" role="dialog" aria-labelledby="archiveDayDetailTitle">

--- a/public/styles.css
+++ b/public/styles.css
@@ -296,8 +296,11 @@ body.view-pilot .topbar-actions{
   gap:18px;
   align-items:start;
 }
-.archive-chart{
+.archive-chart-panel{
+  position:relative;
   grid-column:1;
+}
+.archive-chart{
   width:100%;
   height:100%;
   min-height:320px;
@@ -306,6 +309,38 @@ body.view-pilot .topbar-actions{
   border-radius:16px;
   background:radial-gradient(circle at 15% 25%, rgba(56,189,248,.22), transparent 55%),radial-gradient(circle at 80% 20%, rgba(14,165,233,.18), transparent 60%),radial-gradient(circle at 50% 80%, rgba(59,130,246,.18), transparent 58%),rgba(12,18,32,.96);
   box-shadow:0 32px 60px rgba(2,6,23,.6);
+}
+.archive-chart-filter{
+  position:absolute;
+  top:16px;
+  right:16px;
+  display:flex;
+  flex-direction:column;
+  align-items:flex-start;
+  gap:6px;
+  padding:10px 12px;
+  border-radius:12px;
+  background:rgba(12,18,32,.9);
+  border:1px solid rgba(59,130,246,.45);
+  box-shadow:0 18px 40px rgba(2,6,23,.55);
+  backdrop-filter:blur(8px);
+  z-index:4;
+  min-width:0;
+}
+.archive-chart-filter label{
+  font-size:11px;
+  font-weight:600;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  color:rgba(226,232,240,.72);
+}
+.archive-chart-filter select{
+  min-width:180px;
+  background:rgba(15,23,42,.88);
+  border:1px solid rgba(148,163,184,.38);
+  border-radius:10px;
+  color:var(--text);
+  box-shadow:0 10px 24px rgba(2,6,23,.45);
 }
 .archive-chart-wrap .help{
   grid-column:1 / -1;
@@ -362,6 +397,19 @@ body.view-pilot .topbar-actions{
 @media (max-width:900px){
   .archive-chart-wrap{
     grid-template-columns:1fr;
+  }
+  .archive-chart-panel{
+    grid-column:1;
+  }
+  .archive-chart-filter{
+    position:relative;
+    top:auto;
+    right:auto;
+    width:100%;
+    align-items:stretch;
+  }
+  .archive-chart-filter select{
+    width:100%;
   }
   .archive-day-detail{
     grid-column:1;


### PR DESCRIPTION
## Summary
- replace the archive analytics pilot filter with an operator filter based on entry participation across the selected shows
- relocate the filter control into the chart header and update styling/responsive layout to match the new placement
- adjust supporting helpers to drive operator-aware filtering and guard empty states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_69080ac43e488324b3900e3a2c61c054