### PR TITLE
Move archive operator filter above chart

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -299,6 +299,10 @@ body.view-pilot .topbar-actions{
 .archive-chart-panel{
   position:relative;
   grid-column:1;
+  display:flex;
+  flex-direction:column;
+  align-items:stretch;
+  gap:12px;
 }
 .archive-chart{
   width:100%;
@@ -311,9 +315,9 @@ body.view-pilot .topbar-actions{
   box-shadow:0 32px 60px rgba(2,6,23,.6);
 }
 .archive-chart-filter{
-  position:absolute;
-  top:16px;
-  right:16px;
+  position:static;
+  align-self:flex-end;
+  margin-left:auto;
   display:flex;
   flex-direction:column;
   align-items:flex-start;
@@ -324,7 +328,6 @@ body.view-pilot .topbar-actions{
   border:1px solid rgba(59,130,246,.45);
   box-shadow:0 18px 40px rgba(2,6,23,.55);
   backdrop-filter:blur(8px);
-  z-index:4;
   min-width:0;
 }
 .archive-chart-filter label{
@@ -400,12 +403,12 @@ body.view-pilot .topbar-actions{
   }
   .archive-chart-panel{
     grid-column:1;
+    gap:10px;
   }
   .archive-chart-filter{
-    position:relative;
-    top:auto;
-    right:auto;
     width:100%;
+    align-self:stretch;
+    margin-left:0;
     align-items:stretch;
   }
   .archive-chart-filter select{


### PR DESCRIPTION
## Summary
- reposition the archive operator filter so it sits above the chart instead of overlaying it
- update responsive styles to keep the filter aligned on narrow viewports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_69080e1ee6cc8324b5cc92966c6084df