### PR TITLE
Limit archive webhooks to archived shows

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2164,7 +2164,7 @@ function renderArchiveDetails(show){
   if(!show){
     archiveDetails.innerHTML = '<p class="help">Select an archived show to review its summary.</p>';
     if(archiveMeta){
-      archiveMeta.textContent = 'Shows move here automatically 24 hours after creation and remain for two months.';
+      archiveMeta.textContent = 'Shows move here automatically 12 hours after creation and remain for two months.';
     }
     if(archiveEmpty){
       archiveEmpty.hidden = !(Array.isArray(state.archivedShows) && state.archivedShows.length === 0);

--- a/public/index.html
+++ b/public/index.html
@@ -133,7 +133,7 @@
         </div>
         <div class="col-8">
           <div id="archiveDetails" class="archive-details"></div>
-          <div id="archiveEmpty" class="help">No archived shows yet. Shows are moved here 24 hours after creation and remain available for two months.</div>
+          <div id="archiveEmpty" class="help">No archived shows yet. Shows are moved here 12 hours after creation and remain available for two months.</div>
           <div class="archive-actions row">
             <button id="archiveExportCsv" type="button" class="btn ghost" disabled>Export CSV</button>
             <button id="archiveExportJson" type="button" class="btn ghost" disabled>Export JSON</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -306,8 +306,7 @@ body.view-pilot .topbar-actions{
 }
 .archive-chart{
   width:100%;
-  height:100%;
-  min-height:320px;
+  height:clamp(280px, 45vh, 480px);
   display:block;
   border:1px solid rgba(59,130,246,.45);
   border-radius:16px;

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,7 @@ const express = require('express');
 const morgan = require('morgan');
 const { loadConfig, saveConfig } = require('./configStore');
 const { initProvider, getProvider } = require('./storage');
-const { setWebhookConfig, getWebhookStatus, dispatchEntryEvent, dispatchShowEvent } = require('./webhookDispatcher');
+const { setWebhookConfig, getWebhookStatus, dispatchShowEvent } = require('./webhookDispatcher');
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
@@ -301,8 +301,6 @@ async function bootstrap(){
       res.status(404).json({error: 'Show not found'});
       return;
     }
-    const show = await provider.getShow(req.params.id);
-    await dispatchEntryEvent('entry.created', show, entry);
     res.status(201).json(entry);
   }));
 
@@ -313,8 +311,6 @@ async function bootstrap(){
       res.status(404).json({error: 'Entry not found'});
       return;
     }
-    const show = await provider.getShow(req.params.id);
-    await dispatchEntryEvent('entry.updated', show, entry);
     res.json(entry);
   }));
 

--- a/server/storage/postgresProvider.js
+++ b/server/storage/postgresProvider.js
@@ -3,7 +3,7 @@ const { v4: uuidv4 } = require('uuid');
 
 const { dispatchShowEvent } = require('../webhookDispatcher');
 
-const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const AUTO_ARCHIVE_WINDOW_MS = 12 * 60 * 60 * 1000;
 const ARCHIVE_RETENTION_MONTHS = 2;
 const DEFAULT_PILOTS = ['Alex','Nick','John Henery','James','Robert','Nazar'];
 const DEFAULT_CREW = ['Alex','Nick','John Henery','James','Robert','Nazar'];
@@ -545,7 +545,7 @@ class PostgresProvider {
       if(earliest === null){
         continue;
       }
-      if(now - earliest >= DAY_IN_MS){
+      if(now - earliest >= AUTO_ARCHIVE_WINDOW_MS){
         list.forEach(item => showsToArchive.push(item.show));
       }
     }

--- a/server/storage/sqlProvider.js
+++ b/server/storage/sqlProvider.js
@@ -5,7 +5,7 @@ const { v4: uuidv4 } = require('uuid');
 
 const { dispatchShowEvent } = require('../webhookDispatcher');
 
-const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const AUTO_ARCHIVE_WINDOW_MS = 12 * 60 * 60 * 1000;
 const ARCHIVE_RETENTION_MONTHS = 2;
 const DEFAULT_PILOTS = ['Alex','Nick','John Henery','James','Robert','Nazar'];
 const DEFAULT_CREW = ['Alex','Nick','John Henery','James','Robert','Nazar'];
@@ -699,7 +699,7 @@ class SqlProvider {
       if(earliest === null){
         continue;
       }
-      if(now - earliest >= DAY_IN_MS){
+      if(now - earliest >= AUTO_ARCHIVE_WINDOW_MS){
         const archiveTime = Date.now();
         for(const item of list){
           const normalized = this._normalizeShow(item.show);


### PR DESCRIPTION
## Summary
- stop emitting entry-level webhooks during create/update and rely on show archive events instead
- reduce the automated archive window to 12 hours for SQL.js and Postgres storage providers
- refresh archive UI messaging and clamp the chart height to keep it fully visible without scrolling

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e521c37548324a7c24d2f2f08f836)