### PR TITLE
Add secure authentication and RBAC user management

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -5,8 +5,8 @@ This repository serves a browser-based operations console backed by a Node.js/Ex
 ---
 
 ## Current Application Snapshot (v1 launch)
-- **Front-end** (`public/index.html`, `public/app.js`): vanilla JS single-page interface built around role-specific workspaces (Lead, Pilot, Archive).
-- **Settings drawer**: the hamburger menu now exposes **only the Admin settings**. Pilots and monkey lead rosters, crew lists, unit label, data refresh, and webhook controls all live inside the admin section and require the 4-digit PIN (`ADMIN_PIN` in `public/app.js`).
+- **Front-end** (`public/index.html`, `public/app.js`): vanilla JS single-page interface built around role-specific workspaces (Lead, Operator, Archive) gated by the login/password reset flow.
+- **Settings drawer**: the hamburger menu exposes **only the Admin settings** after authentication. User management, unit label, data refresh, and webhook controls all live inside the admin section and require the signed-in user to have the Admin role.
 - **State & sync**: shared app state and broadcast coordination live in `public/app.js` (`state` object, `setupSyncChannel`). The BroadcastChannel named `monkey-tracker-sync` is used to fan out mutations across tabs.
 - **Server** (`server/index.js` and `server/storage/sqlProvider.js`): Express handles REST endpoints for configuration, staff, shows, entries, and archive operations. Data persists via `sql.js` with JSON payloads, retention, and webhook dispatch support (`server/webhookDispatcher.js`).
 
@@ -19,10 +19,10 @@ This repository serves a browser-based operations console backed by a Node.js/Ex
 ---
 
 ## Admin Drawer Implementation Notes
-- `toggleConfig` in `public/app.js` ensures the drawer opens directly to the admin section and summons the PIN prompt when locked.
+- `toggleConfig` in `public/app.js` ensures the drawer opens directly to the admin section and now verifies the signed-in user has the Admin role before revealing any settings.
 - `setConfigSection` still supports multiple sections, but only the `admin` section remains active. Keep the guard clauses in place if you later reintroduce additional sections.
 - Staff textarea values map 1:1 to the `/api/staff` payload. Maintain the `parseStaffTextarea` normalization rules (trim, dedupe, sort).
-- When modifying Admin UI markup, keep IDs stable (`pilotList`, `monkeyLeadList`, `crewList`, etc.) so existing event handlers continue working.
+- When modifying Admin UI markup, keep IDs stable for the new directory widgets (`userDirectory`, `userForm`, `userName`, `userEmail`, `userFormStatus`, etc.) so existing event handlers continue working.
 
 ---
 
@@ -30,7 +30,7 @@ This repository serves a browser-based operations console backed by a Node.js/Ex
 When you introduce authentication/authorization layers:
 1. **Boundary placement** – add auth middleware in `server/index.js` before route definitions. Encapsulate role checks so front-end workspace toggles can consume a single `GET /api/session` payload describing capabilities.
 2. **Client gating** – centralize role enforcement in `public/app.js` (e.g., `setView`) so new roles don’t bypass restrictions. Consider deriving view availability from a `state.session.roles` array.
-3. **PIN retirement strategy** – transition the hard-coded PIN flow to token-based checks. Preserve backwards compatibility with an environment flag until rollout is complete.
+3. **Auth guard strategy** – keep all sensitive routes and UI sections behind `state.session.roles`. The `PASSWORD_RESET_ALLOW` list plus `apiRequest` error handling should be updated alongside any new endpoints so expired sessions or locked accounts never leak data.
 4. **Sync events** – extend BroadcastChannel messages to include session identifiers to avoid applying stale updates from users who lose access mid-session.
 
 ---
@@ -49,3 +49,36 @@ When you introduce authentication/authorization layers:
 - Document additional manual or automated checks in your pull request descriptions for traceability.
 
 Keep this guide current whenever you adjust critical flows, expand role handling, or modify persistence logic.
+
+---
+
+## Authentication & RBAC architecture
+- `server/userStore.js` seeds the directory from the provided Sphere roster and hashes passwords with `crypto.scrypt`. Accounts are persisted to `data/users.json` (created automatically the first time you start `node server/index.js`).
+- `server/sessionStore.js` issues 12-hour session tokens that are hashed in-memory and stored client-side via an `HttpOnly` `mt_session` cookie. `app.use` middleware in `server/index.js` resolves the session into `req.user` for every `/api/*` request.
+- `public/app.js` drives the login overlay (`#loginScreen`) and the password reset view (`#passwordResetScreen`). `apiRequest` traps `401` responses to bounce the user back to the login form and `423` responses to force the password reset UI.
+- `PASSWORD_RESET_ALLOW` in `server/index.js` whitelists the session/password/logout endpoints so locked accounts can still complete the forced-reset flow.
+
+### Role definitions & permissions
+- **Admin** – access the settings drawer, create/update/delete users, reset passwords, edit config/webhook settings, and invoke admin-only API endpoints.
+- **Lead** – create/update/archive shows and export archives. Leads can also access the archive workspace.
+- **Operator** – log entries against shows via the Operator workspace. Operators also have archive read-only access.
+- **Stagecrew** – appear in crew selection lists and can read archived shows. Stagecrew members do not see Lead/Operator workspaces.
+
+### Admin management workflows
+1. After signing in with an Admin role, open the settings drawer (`#configPanel`). The user directory (`#userDirectory`) auto-loads via `loadUsers()` and renders clickable rows.
+2. Use the inline user form (`#userForm`) to add or update accounts. Required inputs: name, email, and at least one role checkbox (`name="userRole"`).
+3. Saving triggers `/api/users` (`POST` for create, `PUT /api/users/:id` for edits). The UI resets the form, refreshes the directory, reloads the `/api/staff` payload, and calls `notifyStaffChanged()` so other tabs refresh their selectors.
+4. Password resets run through `/api/users/:id/reset-password` and immediately invalidate active sessions via `deleteSessionsForUser` on the server.
+5. Staff selectors (`renderOperatorOptions`, `renderPilotAssignments`, `renderCrewOptions`) always pull from `state.staff`, which is hydrated by `/api/staff` and mirrors the user directory (Operators → operator pickers, Leads → lead/monkey lead selects, Stagecrew → crew multi-select).
+
+### Security considerations
+- Password strength enforcement lives in `server/userStore.js` (`validatePasswordStrength`) and requires 12+ characters with upper/lower/number/symbol. New accounts are flagged with `passwordResetRequired` so the client forces the password reset flow before the SPA loads.
+- Scrypt hashing (per-user salts, `N=16384`) protects stored passwords. `DEFAULT_TEMP_PASSWORD` is only used during seeding or admin-triggered resets.
+- Session cookies are `HttpOnly`/`SameSite=Lax`, and the server hashes session tokens before caching them. `apiRequest` now traps `401/423` statuses to avoid leaking stale state in the SPA when sessions expire or resets are required.
+- `/api/staff` no longer trusts textarea inputs; it is read-only and derives roster data from the user directory to reduce tampering risk.
+
+### Setup instructions
+- Run `node server/index.js` from the repo root to initialize both `data/users.json` and the SQL.js database. The seed list in `server/userStore.js` contains all requested Sphere accounts (Leads/Operators, Stagecrew, and Admins Isaiah Mincher + Zach Harvest).
+- Default password for every new or reset account is `adminsphere1`. Users must change it on first login via the password reset overlay.
+- To bootstrap additional admins for a new environment, either extend `DEFAULT_USER_SEED` in `server/userStore.js` before the first launch or sign in as an existing Admin and create the new account through the UI.
+- Use the login overlay (`/#loginScreen`) to authenticate before the SPA renders. Credentials are cached via the `mt_session` cookie, so refreshing the page keeps you signed in until the 12-hour TTL expires or you click Logout.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ This project exposes the **Drone Tracker** interface as a full web application b
 ## Features
 
 - Full-featured front-end built with HTML and CSS that retains the original look-and-feel and now surfaces a LAN connection dashboard for quick status checks.
+- Secure authentication and role-based access control (Admin, Lead, Operator, Stagecrew) with forced first-login password resets and session tokens.
 - Express.js backend API that manages shows, entries, and configuration.
 - Modular storage provider with SQL.js (default) and PostgreSQL backends. The SQL.js driver keeps zero-dependency persistence while PostgreSQL enables multi-user deployments.
-- Configurable application settings from the in-app settings panel (unit label, webhook delivery settings, and roster management).
+- Configurable application settings from the in-app settings panel (unit label, webhook delivery settings, and the user directory).
 - Optional per-entry webhook export that mirrors the CSV column structure so downstream tables align perfectly with local exports.
 - Archive workspace that retains shows for two months and supports CSV/JSON exports.
 - Entry editor modal with validation consistent with the original workflow.
@@ -30,7 +31,7 @@ This project exposes the **Drone Tracker** interface as a full web application b
 
    The app runs on [http://10.241.211.120:3000](http://10.241.211.120:3000) out of the box. Set the `HOST` and `PORT` environment variables before launching if you need a different binding (for example `HOST=0.0.0.0 node server/index.js`).
 
-3. Open the settings panel (hamburger button) to adjust the unit label, manage pilot/monkey lead/crew rosters, or to enable the webhook exporter. By default the app uses SQLite-on-WASM and stores data in `data/monkey-tracker.sqlite`.
+3. Navigate to [http://10.241.211.120:3000](http://10.241.211.120:3000) (or the host/port you configured) and sign in with one of the seeded accounts listed in `server/userStore.js`. Usernames are email addresses and every new account starts with the temporary password `adminsphere1`, which must be changed on first login. Admins (Isaiah Mincher and Zach Harvest by default) can then open the settings panel (hamburger button) to adjust the unit label, manage the user directory, and configure the webhook exporter. By default the app uses SQLite-on-WASM and stores data in `data/monkey-tracker.sqlite`.
 
 ## Configuration
 
@@ -60,9 +61,18 @@ Environment variables using the standard PostgreSQL naming scheme (`PGHOST`, `PG
 
 When PostgreSQL is active the UI updates the provider badge to “PostgreSQL v1” and all API responses surface the active driver in the `storageMeta` field. The server keeps feature parity with the SQL.js provider, including archive retention and roster seeding.
 
-### Roster management
+### User accounts & roles
 
-The settings panel maintains individual lists for pilots, IATSE monkey leads, and crew. Monkey leads start with Cleo, Bret, Leslie, and Dallas by default and can be customized to match the day's roster.
+Authentication is backed by the JSON user store in `data/users.json` (seeded from `server/userStore.js` on first launch). Accounts are defined by name, email, and one or more roles:
+
+- **Admin** – manage the user directory, reset passwords, configure storage/webhooks.
+- **Lead** – create/update shows and export archives.
+- **Operator** – log entries against active shows.
+- **Stagecrew** – appear in crew assignment lists and can view archives.
+
+Usernames are the email addresses listed in `server/userStore.js`. Every new account receives the temporary password `adminsphere1` and is forced to set a permanent password (minimum 12 characters with upper/lower case, number, and symbol) on first login. Only Admins can create users, update emails, toggle roles, or trigger password resets via the settings drawer.
+
+Workspace selectors automatically pull from the user directory: Lead dropdowns show Lead accounts, Operator pickers show Operator accounts, the Monkey Lead field uses Stagecrew assignments, and crew multi-selects use Stagecrew names as well. Manual textareas for roster maintenance have been removed in favor of the centralized directory.
 
 ### Webhook exporter
 

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,40 @@
   <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
-  <div id="appShell" class="app-shell">
+  <div id="loginScreen" class="auth-view">
+    <div class="auth-card">
+      <img src="./assets/Sphere%20Logo_RGB%20_White.png" alt="Sphere" class="auth-logo" />
+      <h1>Sign in to Monkey Tracker</h1>
+      <p class="help">Use your Sphere email address to continue.</p>
+      <form id="loginForm" class="auth-form">
+        <label for="loginEmail">Email</label>
+        <input id="loginEmail" type="email" autocomplete="username" required />
+        <label for="loginPassword">Password</label>
+        <input id="loginPassword" type="password" autocomplete="current-password" required />
+        <button type="submit" class="btn primary full">Sign in</button>
+        <div id="loginError" class="error" role="alert" hidden></div>
+      </form>
+    </div>
+  </div>
+  <div id="passwordResetScreen" class="auth-view" hidden>
+    <div class="auth-card">
+      <img src="./assets/Sphere%20Logo_RGB%20_White.png" alt="Sphere" class="auth-logo" />
+      <h1>Create a new password</h1>
+      <p class="help">Your temporary password has expired. Set a permanent password that meets the strength rules.</p>
+      <form id="passwordResetForm" class="auth-form">
+        <label for="resetCurrent">Current password</label>
+        <input id="resetCurrent" type="password" autocomplete="current-password" required />
+        <label for="resetNew">New password</label>
+        <input id="resetNew" type="password" autocomplete="new-password" required />
+        <label for="resetConfirm">Confirm new password</label>
+        <input id="resetConfirm" type="password" autocomplete="new-password" required />
+        <button type="submit" class="btn primary full">Update password</button>
+        <button type="button" id="passwordResetLogout" class="btn ghost full">Log out</button>
+        <div id="passwordResetError" class="error" role="alert" hidden></div>
+      </form>
+    </div>
+  </div>
+  <div id="appShell" class="app-shell" hidden>
     <aside id="configPanel" class="config" role="dialog" aria-modal="true" aria-labelledby="configTitle" aria-hidden="true">
       <div class="toolbar config-header">
         <h2 id="configTitle">Workspace menu</h2>
@@ -15,31 +48,39 @@
       <nav class="config-nav" aria-label="Settings categories">
         <button type="button" class="config-nav-btn is-active" data-config-target="admin">Admin settings</button>
       </nav>
-      <div id="adminPinPrompt" class="pin-prompt" role="alertdialog" aria-modal="true" aria-labelledby="adminPinTitle" hidden>
-        <div class="pin-card">
-          <h3 id="adminPinTitle">Admin PIN required</h3>
-          <p class="help">Enter the 4-digit PIN to continue.</p>
-          <label for="adminPinInput">PIN</label>
-          <input id="adminPinInput" type="password" inputmode="numeric" pattern="[0-9]*" maxlength="4" autocomplete="off" />
-          <div class="row pin-actions">
-            <button type="button" id="adminPinCancel" class="btn ghost">Cancel</button>
-            <button type="button" id="adminPinSubmit" class="btn primary">Unlock</button>
-          </div>
-          <div id="adminPinError" class="error" role="alert" hidden>Incorrect PIN. Try again.</div>
-        </div>
-      </div>
       <form id="configForm" class="config-form">
         <section class="config-section grid is-active" data-config-section="admin">
-          <fieldset id="staffFields" class="col-12 provider-fields">
-            <legend>Pilots, monkey leads &amp; crew</legend>
-            <p class="help">Add one name per line. These lists feed the Lead and Pilot workspaces.</p>
-            <label for="pilotList">Pilots</label>
-            <textarea id="pilotList" class="list-input" placeholder="e.g., Alex"></textarea>
-            <label for="monkeyLeadList">Monkey leads</label>
-            <textarea id="monkeyLeadList" class="list-input" placeholder="e.g., Cleo"></textarea>
-            <label for="crewList">Crew</label>
-            <textarea id="crewList" class="list-input" placeholder="e.g., Jamie"></textarea>
-          </fieldset>
+          <div class="col-12 admin-users-panel">
+            <h3 id="userAccountsTitle">User accounts</h3>
+            <p class="help">Admins manage the roster here. Workspace lists automatically sync to assigned roles.</p>
+            <div id="userDirectory" class="user-directory" aria-live="polite"></div>
+            <div id="userForm" class="user-form" role="form" aria-labelledby="userAccountsTitle">
+              <input type="hidden" id="userId" />
+              <div class="grid">
+                <div class="col-6">
+                  <label for="userName">Name</label>
+                  <input id="userName" type="text" required />
+                </div>
+                <div class="col-6">
+                  <label for="userEmail">Email</label>
+                  <input id="userEmail" type="email" required />
+                </div>
+                <fieldset class="col-12 role-checkboxes">
+                  <legend>Roles</legend>
+                  <label><input type="checkbox" value="lead" name="userRole" /> Lead</label>
+                  <label><input type="checkbox" value="operator" name="userRole" /> Operator</label>
+                  <label><input type="checkbox" value="stagecrew" name="userRole" /> Stagecrew</label>
+                  <label><input type="checkbox" value="admin" name="userRole" /> Admin</label>
+                </fieldset>
+              </div>
+              <div class="row form-actions">
+                <button type="button" id="userFormCancel" class="btn ghost">Cancel</button>
+                <button type="button" id="userFormSubmit" class="btn primary">Save user</button>
+              </div>
+              <p class="help small">New accounts receive the temporary password <code>adminsphere1</code> and must update it on first login.</p>
+              <div id="userFormStatus" class="help" role="status"></div>
+            </div>
+          </div>
           <div class="col-12">
             <label for="unitLabelSelect">Unit label</label>
             <select id="unitLabelSelect" name="unitLabel">
@@ -89,6 +130,13 @@
           </button>
           <div class="topbar-actions">
             <button id="roleHome" class="btn ghost" type="button">← Choose workspace</button>
+            <div id="sessionUser" class="session-user" hidden>
+              <div class="session-user-text">
+                <strong id="sessionName"></strong>
+                <span id="sessionRoles"></span>
+              </div>
+              <button id="logoutBtn" class="btn ghost small" type="button">Logout</button>
+            </div>
           </div>
           <img src="./assets/Sphere%20Logo_RGB%20_White.png" alt="Sphere" class="app-logo" />
           <div class="topbar-title">
@@ -108,13 +156,13 @@
       <div class="role-options">
         <div class="role-options-main">
           <button id="chooseLead" type="button" class="btn primary role-btn">Lead</button>
-          <button id="choosePilot" type="button" class="btn primary role-btn">Pilot</button>
+          <button id="chooseOperator" type="button" class="btn primary role-btn">Operator</button>
         </div>
         <div class="role-options-archive">
           <button id="chooseArchive" type="button" class="btn primary role-btn">Archive</button>
         </div>
       </div>
-      <p class="help">Lead sets up shows and manages exports. Pilot logs entries against those shows.</p>
+      <p class="help">Lead sets up shows and manages exports. Operator logs entries against those shows.</p>
     </section>
 
     <section id="archiveView" class="panel view-archive-only" aria-labelledby="archiveTitle">
@@ -211,7 +259,7 @@
           <input id="showLabel" type="text" placeholder="e.g., 7pm Main" required />
         </div>
         <div class="col-6">
-          <label for="leadPilot">Lead Pilot</label>
+          <label for="leadPilot">Lead</label>
           <select id="leadPilot" required></select>
         </div>
         <div class="col-6">
@@ -225,13 +273,13 @@
       </div>
     </section>
 
-    <section class="panel view-pilot-only" aria-labelledby="entryTitle">
+    <section class="panel view-operator-only" aria-labelledby="entryTitle">
       <h2 id="entryTitle">Entry form</h2>
       <div class="grid" id="entryForm">
         <div class="col-12">
           <label for="entryShowSelect">Assign to show</label>
           <select id="entryShowSelect"></select>
-          <div id="pilotShowSummary" class="help">Select a show to start logging entries.</div>
+          <div id="operatorShowSummary" class="help">Select a show to start logging entries.</div>
         </div>
         <div class="col-2">
           <label for="unitId"><span id="unitLabel">Monkey</span> ID</label>

--- a/public/styles.css
+++ b/public/styles.css
@@ -33,6 +33,36 @@ body{
   -webkit-font-smoothing:antialiased;
   text-rendering:optimizeLegibility;
 }
+.auth-view{
+  min-height:100vh;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:var(--bg);
+  padding:40px 16px;
+}
+.auth-view[hidden]{display:none !important;}
+.auth-card{
+  width:min(100%, 460px);
+  background:var(--panel);
+  border:1px solid rgba(255,255,255,.1);
+  border-radius:24px;
+  padding:32px;
+  box-shadow:0 30px 60px rgba(0,0,0,.45);
+}
+.auth-card h1{margin-bottom:8px;font-size:24px;}
+.auth-logo{height:32px;width:auto;margin-bottom:20px;display:block;}
+.auth-form{display:flex;flex-direction:column;gap:12px;margin-top:12px;}
+.auth-form label{font-weight:600;font-size:14px;color:var(--text);}
+.auth-form input{
+  border:1px solid rgba(255,255,255,.15);
+  background:var(--input);
+  color:var(--text);
+  border-radius:12px;
+  padding:12px;
+  font-size:15px;
+}
+.auth-form .error{margin:0;}
 body.view-landing{
   background:var(--bg) url("./assets/woz_4d_m.jpg") center/cover no-repeat;
 }
@@ -47,19 +77,19 @@ a{color:var(--primary);text-decoration:none}
 }
 #roleHome{display:none}
 body.view-lead #roleHome,
-body.view-pilot #roleHome,
+body.view-operator #roleHome,
 body.view-archive #roleHome{display:inline-flex}
 #viewBadge{display:none}
 body.view-lead #viewBadge,
-body.view-pilot #viewBadge,
+body.view-operator #viewBadge,
 body.view-archive #viewBadge{display:inline-flex}
 body.view-landing #refreshShows{display:none}
 .view-lead-only,
-.view-pilot-only,
+.view-operator-only,
 .view-landing-only,
 .view-archive-only{display:none !important}
 body.view-lead .view-lead-only{display:block !important}
-body.view-pilot .view-pilot-only{display:block !important}
+body.view-operator .view-operator-only{display:block !important}
 body.view-landing .view-landing-only{display:block !important}
 body.view-archive .view-archive-only{display:block !important}
 #landingView{display:none;text-align:center;padding:38px 20px}
@@ -115,13 +145,13 @@ body.view-landing #landingView{display:block}
   line-height:1;
   color:var(--primary);
 }
-.view-badge-pilot{
+.view-badge-operator{
   color:#bff7d9;
 }
-.view-badge-pilot::before{
+.view-badge-operator::before{
   color:var(--success);
 }
-#pilotShowSummary{margin-top:8px;padding:10px 12px;border:1px dashed var(--border);border-radius:10px;background:rgba(255,255,255,.03);color:var(--text-dim);font-size:13px;text-align:left}
+#operatorShowSummary{margin-top:8px;padding:10px 12px;border:1px dashed var(--border);border-radius:10px;background:rgba(255,255,255,.03);color:var(--text-dim);font-size:13px;text-align:left}
 .app-shell{position:relative;min-height:100vh;overflow-x:hidden;}
 .app-main{
   position:relative;
@@ -165,9 +195,23 @@ body.menu-open .app-main{
   justify-self:start;
 }
 body.view-lead .topbar-actions,
-body.view-pilot .topbar-actions{
+body.view-operator .topbar-actions{
   justify-self:start;
 }
+.session-user{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  padding:8px 14px;
+  border:1px solid rgba(255,255,255,.12);
+  border-radius:14px;
+  background:rgba(14,16,22,.65);
+  box-shadow:0 8px 18px rgba(0,0,0,.35);
+}
+.session-user-text{display:flex;flex-direction:column;line-height:1.2;}
+.session-user strong{font-size:14px;}
+.session-user span{font-size:12px;color:var(--text-dim);}
+.session-user .btn{margin-left:auto;}
 .topbar-title{
   grid-area:title;
   margin-left:auto;
@@ -219,9 +263,43 @@ body.view-pilot .topbar-actions{
 }
 .row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
 .grow{flex:1}
-.badge{
+.badge{  
   background:var(--chip); color:var(--text-dim); padding:6px 10px; border-radius:999px; font-size:12px; border:1px solid var(--border)
 }
+.badge.warn{background:rgba(255,184,77,.18);color:#ffda9c;border-color:rgba(255,184,77,.6);}
+.user-directory{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  padding:16px;
+  margin:16px 0;
+  border:1px dashed rgba(255,255,255,.2);
+  border-radius:14px;
+  background:rgba(11,18,30,.65);
+  max-height:260px;
+  overflow:auto;
+}
+.user-form{
+  padding:18px;
+  border:1px solid rgba(255,255,255,.18);
+  border-radius:16px;
+  background:rgba(8,15,25,.75);
+  box-shadow:0 16px 32px rgba(0,0,0,.35);
+}
+.user-row{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:12px;
+  padding:12px 14px;
+  border:1px solid rgba(255,255,255,.15);
+  border-radius:12px;
+  background:rgba(20,26,38,.7);
+}
+.user-row-info{display:flex;flex-direction:column;gap:2px;}
+.user-row-info strong{font-size:15px;}
+.user-row-info span{font-size:13px;color:var(--text-dim);}
+.user-row-actions{display:flex;gap:8px;}
 .panel{
   background:var(--panel);
   border:1px solid var(--border);
@@ -742,12 +820,16 @@ input.is-invalid:focus, select.is-invalid:focus, textarea.is-invalid:focus{
   --btn-hover-border:#1d4ed8;
   --btn-hover-color:#f8faff;
 }
+.btn.role-btn.is-disabled{
+  opacity:.45;
+  pointer-events:none;
+}
 #chooseLead.btn.role-btn{
   --btn-hover-bg:#2563eb;
   --btn-hover-border:#1d4ed8;
   --btn-hover-color:#f8faff;
 }
-#choosePilot.btn.role-btn{
+#chooseOperator.btn.role-btn{
   --btn-hover-bg:#16a34a;
   --btn-hover-border:#15803d;
   --btn-hover-color:#f1fff7;

--- a/server/sessionStore.js
+++ b/server/sessionStore.js
@@ -1,0 +1,84 @@
+const crypto = require('crypto');
+
+const SESSION_TTL_MS = 12 * 60 * 60 * 1000;
+const SESSION_COOKIE_NAME = 'mt_session';
+
+const sessions = new Map();
+
+function hashToken(token){
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+function createSession(userId){
+  const token = crypto.randomBytes(48).toString('hex');
+  const tokenHash = hashToken(token);
+  const now = Date.now();
+  const expiresAt = now + SESSION_TTL_MS;
+  sessions.set(tokenHash, {userId, createdAt: now, expiresAt});
+  return {token, expiresAt};
+}
+
+function getSession(token){
+  if(!token){
+    return null;
+  }
+  const tokenHash = hashToken(token);
+  const session = sessions.get(tokenHash);
+  if(!session){
+    return null;
+  }
+  if(session.expiresAt <= Date.now()){
+    sessions.delete(tokenHash);
+    return null;
+  }
+  return {...session, tokenHash};
+}
+
+function touchSession(token){
+  const existing = getSession(token);
+  if(!existing){
+    return null;
+  }
+  const newExpires = Date.now() + SESSION_TTL_MS;
+  sessions.set(existing.tokenHash, {userId: existing.userId, createdAt: existing.createdAt, expiresAt: newExpires});
+  return {userId: existing.userId, expiresAt: newExpires};
+}
+
+function deleteSession(token){
+  if(!token){
+    return;
+  }
+  const tokenHash = hashToken(token);
+  sessions.delete(tokenHash);
+}
+
+function deleteSessionsForUser(userId){
+  if(!userId){
+    return;
+  }
+  for(const [tokenHash, session] of sessions.entries()){
+    if(session.userId === userId){
+      sessions.delete(tokenHash);
+    }
+  }
+}
+
+function purgeExpiredSessions(){
+  const now = Date.now();
+  for(const [tokenHash, session] of sessions.entries()){
+    if(session.expiresAt <= now){
+      sessions.delete(tokenHash);
+    }
+  }
+}
+
+module.exports = {
+  createSession,
+  getSession,
+  touchSession,
+  deleteSession,
+  deleteSessionsForUser,
+  purgeExpiredSessions,
+  SESSION_TTL_MS,
+  SESSION_COOKIE_NAME
+};

--- a/server/storage/postgresProvider.js
+++ b/server/storage/postgresProvider.js
@@ -166,7 +166,7 @@ class PostgresProvider {
       id: entryInput.id || uuidv4(),
       ts: entryInput.ts || Date.now()
     });
-    this._assertPilotUnique(show, entry);
+    this._assertOperatorUnique(show, entry);
     const idx = show.entries.findIndex(e => e.id === entry.id);
     if(idx >= 0){
       show.entries[idx] = entry;
@@ -192,7 +192,7 @@ class PostgresProvider {
       ...show.entries[idx],
       ...updates
     });
-    this._assertPilotUnique(show, entry);
+    this._assertOperatorUnique(show, entry);
     show.entries[idx] = entry;
     show.updatedAt = Date.now();
     await this._persist(show);
@@ -369,7 +369,7 @@ class PostgresProvider {
     }
   }
 
-  _assertPilotUnique(show, entry){
+  _assertOperatorUnique(show, entry){
     if(!show){
       return;
     }
@@ -388,7 +388,7 @@ class PostgresProvider {
       return existingPilot === normalized;
     });
     if(hasDuplicate){
-      const err = new Error('Pilot already has an entry for this show.');
+      const err = new Error('Operator already has an entry for this show.');
       err.status = 400;
       throw err;
     }

--- a/server/storage/sqlProvider.js
+++ b/server/storage/sqlProvider.js
@@ -166,7 +166,7 @@ class SqlProvider {
       id: entryInput.id || uuidv4(),
       ts: entryInput.ts || Date.now()
     });
-    this._assertPilotUnique(show, entry);
+    this._assertOperatorUnique(show, entry);
     const idx = show.entries.findIndex(e => e.id === entry.id);
     if(idx >= 0){
       show.entries[idx] = entry;
@@ -192,7 +192,7 @@ class SqlProvider {
       ...show.entries[idx],
       ...updates
     });
-    this._assertPilotUnique(show, entry);
+    this._assertOperatorUnique(show, entry);
     show.entries[idx] = entry;
     show.updatedAt = Date.now();
     await this._persist(show);
@@ -370,7 +370,7 @@ class SqlProvider {
     }
   }
 
-  _assertPilotUnique(show, entry){
+  _assertOperatorUnique(show, entry){
     if(!show){
       return;
     }
@@ -389,7 +389,7 @@ class SqlProvider {
       return existingPilot === normalized;
     });
     if(hasDuplicate){
-      const err = new Error('Pilot already has an entry for this show.');
+      const err = new Error('Operator already has an entry for this show.');
       err.status = 400;
       throw err;
     }

--- a/server/userStore.js
+++ b/server/userStore.js
@@ -1,0 +1,361 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { v4: uuidv4 } = require('uuid');
+
+const USERS_FILE = path.join(process.cwd(), 'data', 'users.json');
+const SUPPORTED_ROLES = ['admin', 'lead', 'operator', 'stagecrew'];
+const DEFAULT_TEMP_PASSWORD = 'adminsphere1';
+const SCRYPT_PARAMS = {N: 16384, r: 8, p: 1, keylen: 64};
+
+const DEFAULT_USER_SEED = [
+  {name: 'Alex Brodnik', email: 'alexander.brodnik@thesphere.com', roles: ['lead', 'operator']},
+  {name: 'John Henry', email: 'john.henry@thesphere.com', roles: ['lead', 'operator']},
+  {name: 'James Johnson', email: 'james.johnson@thesphere.com', roles: ['lead', 'operator']},
+  {name: 'Nazar Vasylyk', email: 'nazar.vasylyk@thesphere.com', roles: ['lead', 'operator']},
+  {name: 'Nicholas Aquino', email: 'nicholas.aquino@thesphere.com', roles: ['lead', 'operator']},
+  {name: 'Robert Ontell', email: 'robert.ontell@thesphere.com', roles: ['lead', 'operator']},
+  {name: 'Ben Ellingson', email: 'benellingson@mac.com', roles: ['lead', 'operator']},
+  {name: 'Alaz Szabo', email: 'alanszabojr@me.com', roles: ['lead', 'operator']},
+  {name: 'John Graham', email: 'john@vigilantaerialsystems.com', roles: ['lead', 'operator']},
+  {name: 'Daniel Perrier', email: 'dnlperrier08@gmail.com', roles: ['lead', 'operator']},
+  {name: 'Jevin Williams', email: 'jevinwilliams@gmail.com', roles: ['lead', 'operator']},
+  {name: 'Gregory Ryan', email: 'gregorywryan@gmail.com', roles: ['lead', 'operator']},
+  {name: 'Jordan Schroeder', email: 'jtsschroeder7@gmail.com', roles: ['lead', 'operator']},
+  {name: 'Danny Szabo', email: 'dannyszabo@gmail.com', roles: ['lead', 'operator']},
+  {name: 'Ben Storick', email: 'bestorick@gmail.com', roles: ['lead', 'operator']},
+  {name: 'Isaiah Mincher', email: 'isaiah.mincher@thesphere.com', roles: ['admin']},
+  {name: 'Zach Harvest', email: 'zach.harvest@thesphere.com', roles: ['admin']},
+  {name: 'Bret Tuttle', email: 'bret.tuttle@thesphere.com', roles: ['stagecrew']},
+  {name: 'Cleo Kelley', email: 'cleo.kelley@thesphere.com', roles: ['stagecrew']},
+  {name: 'Dallas Howerton', email: 'dallas.howerton@thesphere.com', roles: ['stagecrew']},
+  {name: 'Daisy Serratos Gomez', email: 'daisy.serratosgomez@thesphere.com', roles: ['stagecrew']}
+];
+
+let userRecords = [];
+let initialized = false;
+
+async function initUserStore(){
+  if(initialized){
+    return;
+  }
+  await fs.promises.mkdir(path.dirname(USERS_FILE), {recursive: true});
+  if(await fileExists(USERS_FILE)){
+    await loadUsersFromFile();
+  }else{
+    userRecords = seedDefaultUsers();
+    await persistUsers();
+  }
+  if(userRecords.length === 0){
+    userRecords = seedDefaultUsers();
+    await persistUsers();
+  }
+  initialized = true;
+}
+
+async function loadUsersFromFile(){
+  try{
+    const raw = await fs.promises.readFile(USERS_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if(Array.isArray(parsed.users)){
+      userRecords = parsed.users.map(normalizeStoredUser).filter(Boolean);
+    }else{
+      userRecords = [];
+    }
+  }catch(err){
+    console.warn('Failed to parse user store. Recreating seed data.', err);
+    userRecords = seedDefaultUsers();
+    await persistUsers();
+  }
+}
+
+function seedDefaultUsers(){
+  const now = new Date().toISOString();
+  return DEFAULT_USER_SEED.map(seed =>{
+    const password = hashPassword(DEFAULT_TEMP_PASSWORD);
+    return {
+      id: uuidv4(),
+      name: seed.name,
+      email: normalizeEmail(seed.email),
+      roles: normalizeRoles(seed.roles),
+      password,
+      passwordResetRequired: true,
+      createdAt: now,
+      updatedAt: now
+    };
+  });
+}
+
+async function persistUsers(){
+  const payload = {users: userRecords};
+  await fs.promises.writeFile(USERS_FILE, JSON.stringify(payload, null, 2));
+}
+
+function normalizeStoredUser(raw){
+  if(!raw || typeof raw !== 'object'){
+    return null;
+  }
+  const normalizedRoles = normalizeRoles(raw.roles);
+  const password = typeof raw.password === 'object'
+    ? {
+        hash: String(raw.password.hash || ''),
+        salt: raw.password.salt || raw.passwordSalt || '',
+        algorithm: raw.password.algorithm || 'scrypt',
+        params: raw.password.params || {N: raw.password.N || SCRYPT_PARAMS.N, r: raw.password.r || SCRYPT_PARAMS.r, p: raw.password.p || SCRYPT_PARAMS.p, keylen: raw.password.keylen || SCRYPT_PARAMS.keylen}
+      }
+    : hashPassword(DEFAULT_TEMP_PASSWORD);
+  return {
+    id: raw.id || uuidv4(),
+    name: typeof raw.name === 'string' ? raw.name.trim() : 'User',
+    email: normalizeEmail(raw.email),
+    roles: normalizedRoles,
+    password,
+    passwordResetRequired: Boolean(raw.passwordResetRequired),
+    createdAt: raw.createdAt || new Date().toISOString(),
+    updatedAt: raw.updatedAt || raw.createdAt || new Date().toISOString()
+  };
+}
+
+function hashPassword(password, salt){
+  if(typeof salt !== 'string' || !salt){
+    salt = crypto.randomBytes(16).toString('hex');
+  }
+  const hash = crypto.scryptSync(password, salt, SCRYPT_PARAMS.keylen, {N: SCRYPT_PARAMS.N, r: SCRYPT_PARAMS.r, p: SCRYPT_PARAMS.p}).toString('hex');
+  return {
+    hash,
+    salt,
+    algorithm: 'scrypt',
+    params: {...SCRYPT_PARAMS}
+  };
+}
+
+function verifyPassword(record, password){
+  if(!record || !password || typeof password !== 'string'){
+    return false;
+  }
+  const stored = record.password;
+  if(!stored || !stored.hash || !stored.salt){
+    return false;
+  }
+  try{
+    const hash = crypto.scryptSync(password, stored.salt, stored.params?.keylen || SCRYPT_PARAMS.keylen, {
+      N: stored.params?.N || SCRYPT_PARAMS.N,
+      r: stored.params?.r || SCRYPT_PARAMS.r,
+      p: stored.params?.p || SCRYPT_PARAMS.p
+    }).toString('hex');
+    return crypto.timingSafeEqual(Buffer.from(hash, 'hex'), Buffer.from(stored.hash, 'hex'));
+  }catch(err){
+    return false;
+  }
+}
+
+function normalizeRoles(input){
+  const set = new Set();
+  const roles = Array.isArray(input) ? input : (typeof input === 'string' ? input.split(',') : []);
+  roles.forEach(role =>{
+    const value = typeof role === 'string' ? role.trim().toLowerCase() : '';
+    if(SUPPORTED_ROLES.includes(value)){
+      set.add(value);
+    }
+  });
+  return Array.from(set);
+}
+
+function normalizeEmail(email){
+  return typeof email === 'string' ? email.trim().toLowerCase() : '';
+}
+
+function sanitizeName(name){
+  return typeof name === 'string' && name.trim() ? name.trim() : 'Unnamed user';
+}
+
+function sanitizeUser(record){
+  return {
+    id: record.id,
+    name: record.name,
+    email: record.email,
+    roles: record.roles.slice().sort(),
+    needsPasswordReset: Boolean(record.passwordResetRequired),
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt
+  };
+}
+
+function listUsers(){
+  return userRecords
+    .slice()
+    .sort((a, b)=> a.name.localeCompare(b.name, undefined, {sensitivity: 'base'}))
+    .map(sanitizeUser);
+}
+
+function findUserByEmail(email){
+  const normalized = normalizeEmail(email);
+  return userRecords.find(user => user.email === normalized) || null;
+}
+
+function findUserById(id){
+  return userRecords.find(user => user.id === id) || null;
+}
+
+function ensureUniqueEmail(candidateEmail, ignoreUserId){
+  const normalized = normalizeEmail(candidateEmail);
+  if(!normalized){
+    const err = new Error('Email is required');
+    err.status = 400;
+    throw err;
+  }
+  const existing = findUserByEmail(normalized);
+  if(existing && existing.id !== ignoreUserId){
+    const err = new Error('Email already exists');
+    err.status = 409;
+    throw err;
+  }
+  return normalized;
+}
+
+async function createUser(input){
+  const name = sanitizeName(input?.name);
+  const email = ensureUniqueEmail(input?.email);
+  const roles = normalizeRoles(input?.roles);
+  if(!roles.length){
+    const err = new Error('Select at least one role');
+    err.status = 400;
+    throw err;
+  }
+  const now = new Date().toISOString();
+  const password = hashPassword(DEFAULT_TEMP_PASSWORD);
+  const record = {
+    id: uuidv4(),
+    name,
+    email,
+    roles,
+    password,
+    passwordResetRequired: true,
+    createdAt: now,
+    updatedAt: now
+  };
+  userRecords.push(record);
+  await persistUsers();
+  return sanitizeUser(record);
+}
+
+async function updateUser(id, updates){
+  const record = findUserById(id);
+  if(!record){
+    const err = new Error('User not found');
+    err.status = 404;
+    throw err;
+  }
+  const nextEmail = updates?.email ? ensureUniqueEmail(updates.email, record.id) : record.email;
+  const nextName = typeof updates?.name === 'string' && updates.name.trim() ? updates.name.trim() : record.name;
+  const nextRoles = Array.isArray(updates?.roles)
+    ? normalizeRoles(updates.roles)
+    : record.roles;
+  if(nextRoles.length === 0){
+    const err = new Error('Select at least one role');
+    err.status = 400;
+    throw err;
+  }
+  record.name = nextName;
+  record.email = nextEmail;
+  record.roles = nextRoles;
+  record.updatedAt = new Date().toISOString();
+  await persistUsers();
+  return sanitizeUser(record);
+}
+
+async function setUserPassword(id, password, options = {}){
+  const record = findUserById(id);
+  if(!record){
+    const err = new Error('User not found');
+    err.status = 404;
+    throw err;
+  }
+  validatePasswordStrength(password);
+  record.password = hashPassword(password);
+  record.passwordResetRequired = Boolean(options.requireReset);
+  record.updatedAt = new Date().toISOString();
+  await persistUsers();
+  return sanitizeUser(record);
+}
+
+async function resetUserPassword(id){
+  const record = findUserById(id);
+  if(!record){
+    const err = new Error('User not found');
+    err.status = 404;
+    throw err;
+  }
+  record.password = hashPassword(DEFAULT_TEMP_PASSWORD);
+  record.passwordResetRequired = true;
+  record.updatedAt = new Date().toISOString();
+  await persistUsers();
+  return sanitizeUser(record);
+}
+
+function validatePasswordStrength(password){
+  if(typeof password !== 'string' || password.length < 12){
+    const err = new Error('Password must be at least 12 characters long');
+    err.status = 400;
+    throw err;
+  }
+  if(!/[a-z]/.test(password) || !/[A-Z]/.test(password) || !/[0-9]/.test(password) || !/[^A-Za-z0-9]/.test(password)){
+    const err = new Error('Password must include upper, lower, number and special characters');
+    err.status = 400;
+    throw err;
+  }
+}
+
+function getRoleDirectory(){
+  const leads = userRecords
+    .filter(user => user.roles.includes('lead'))
+    .map(user => user.name)
+    .sort((a, b)=> a.localeCompare(b, undefined, {sensitivity: 'base'}));
+  const operators = userRecords
+    .filter(user => user.roles.includes('operator'))
+    .map(user => user.name)
+    .sort((a, b)=> a.localeCompare(b, undefined, {sensitivity: 'base'}));
+  const stagecrew = userRecords
+    .filter(user => user.roles.includes('stagecrew'))
+    .map(user => user.name)
+    .sort((a, b)=> a.localeCompare(b, undefined, {sensitivity: 'base'}));
+  return {leads, operators, stagecrew};
+}
+
+async function deleteUser(id){
+  const index = userRecords.findIndex(user => user.id === id);
+  if(index === -1){
+    const err = new Error('User not found');
+    err.status = 404;
+    throw err;
+  }
+  const [removed] = userRecords.splice(index, 1);
+  await persistUsers();
+  return sanitizeUser(removed);
+}
+
+async function fileExists(file){
+  try{
+    await fs.promises.access(file, fs.constants.F_OK);
+    return true;
+  }catch(err){
+    return false;
+  }
+}
+
+module.exports = {
+  initUserStore,
+  listUsers,
+  createUser,
+  updateUser,
+  deleteUser,
+  setUserPassword,
+  resetUserPassword,
+  validatePasswordStrength,
+  verifyPassword: (record, password) => verifyPassword(record, password),
+  findUserByEmail,
+  findUserById,
+  sanitizeUser,
+  getRoleDirectory,
+  DEFAULT_TEMP_PASSWORD
+};


### PR DESCRIPTION
## Summary
- add the login/password reset UI plus session handling so every workspace is gated by authenticated user accounts
- implement the admin-only user directory backed by the new userStore/sessionStore modules and wire staff selectors to role-based data
- refresh styles/docs to cover the authentication architecture and role workflows while renaming the Operator workspace

## Testing
- npm test
- curl -i -c /tmp/mt_cookies.txt -H 'Content-Type: application/json' -d '{"email":"alexander.brodnik@thesphere.com","password":"adminsphere1"}' http://127.0.0.1:3000/api/auth/login
- curl -i -b /tmp/mt_cookies.txt -c /tmp/mt_cookies.txt -H 'Content-Type: application/json' -d '{"currentPassword":"adminsphere1","newPassword":"TempPass123!@#"}' http://127.0.0.1:3000/api/auth/password
- curl -s -b /tmp/mt_cookies.txt http://127.0.0.1:3000/api/staff

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6916200f17cc83238bee1011706131f3)