### PR TITLE
Fix admin landing view and add admin workspace

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,9 +45,72 @@
       <div class="toolbar config-header">
         <h2 id="configTitle">Workspace menu</h2>
       </div>
-      <nav class="config-nav" aria-label="Settings categories">
-        <button type="button" class="config-nav-btn is-active" data-config-target="admin">Admin settings</button>
+      <nav class="config-nav" aria-label="Workspace shortcuts">
+        <button type="button" class="config-nav-btn" data-config-target="landing">Choose workspace</button>
+        <button type="button" class="config-nav-btn" data-config-target="admin" id="adminWorkspaceNav">Admin workspace</button>
       </nav>
+      <p class="help">Use the shortcuts above to jump between views. Admin access is required to open the admin workspace.</p>
+      <div class="config-actions row">
+        <div class="grow"></div>
+        <button type="button" id="cancelConfig" class="btn ghost">Close menu</button>
+      </div>
+    </aside>
+
+    <div id="appMain" class="app-main">
+      <div class="topbar" role="banner">
+        <div class="topbar-toolbar">
+          <button id="configBtn" class="btn icon-btn hamburger-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Toggle settings">
+            <span class="hamburger-icon" aria-hidden="true">
+              <span></span>
+              <span></span>
+              <span></span>
+            </span>
+            <span class="sr-only">Toggle settings</span>
+          </button>
+          <div class="topbar-actions">
+            <button id="roleHome" class="btn ghost" type="button">← Choose workspace</button>
+            <div id="sessionUser" class="session-user" hidden>
+              <div class="session-user-text">
+                <strong id="sessionName"></strong>
+                <span id="sessionRoles"></span>
+              </div>
+              <button id="logoutBtn" class="btn ghost small" type="button">Logout</button>
+            </div>
+          </div>
+          <img src="./assets/Sphere%20Logo_RGB%20_White.png" alt="Sphere" class="app-logo" />
+          <div class="topbar-title">
+            <span id="viewBadge" class="view-badge">Lead workspace</span>
+            <div class="title-stack">
+              <h1 class="app-title">Flight Log Form</h1>
+              <span class="title-sub">Tracking <span id="appTitle">Drone</span> activity</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="container" role="main">
+    <section id="landingView" class="panel landing-panel view-landing-only" aria-labelledby="landingTitle">
+      <h2 id="landingTitle">Choose workspace</h2>
+      <p class="lead">Select the role you need for this session.</p>
+      <div class="role-options">
+        <div class="role-options-main">
+          <button id="chooseLead" type="button" class="btn primary role-btn">Lead</button>
+          <button id="chooseOperator" type="button" class="btn primary role-btn">Operator</button>
+        </div>
+        <div class="role-options-archive">
+          <button id="chooseArchive" type="button" class="btn primary role-btn">Archive</button>
+        </div>
+      </div>
+      <p class="help">Lead sets up shows and manages exports. Operator logs entries against those shows.</p>
+    </section>
+
+    <section id="adminView" class="panel view-admin-only" aria-labelledby="adminTitle">
+      <div class="panel-header">
+        <h2 id="adminTitle">Admin workspace</h2>
+        <div class="panel-actions">
+          <p class="help">Manage accounts, unit labels, and integrations.</p>
+        </div>
+      </div>
       <form id="configForm" class="config-form">
         <section class="config-section grid is-active" data-config-section="admin">
           <div class="col-12 admin-users-panel">
@@ -108,61 +171,12 @@
         </section>
         <div class="config-actions row">
           <div class="grow"></div>
-          <button type="button" id="cancelConfig" class="btn ghost">Cancel</button>
           <button type="submit" class="btn primary">Save settings</button>
         </div>
         <div class="config-status">
           <div id="configMessage" role="status" aria-live="polite" class="help"></div>
         </div>
       </form>
-    </aside>
-
-    <div id="appMain" class="app-main">
-      <div class="topbar" role="banner">
-        <div class="topbar-toolbar">
-          <button id="configBtn" class="btn icon-btn hamburger-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="configPanel" title="Toggle settings">
-            <span class="hamburger-icon" aria-hidden="true">
-              <span></span>
-              <span></span>
-              <span></span>
-            </span>
-            <span class="sr-only">Toggle settings</span>
-          </button>
-          <div class="topbar-actions">
-            <button id="roleHome" class="btn ghost" type="button">← Choose workspace</button>
-            <div id="sessionUser" class="session-user" hidden>
-              <div class="session-user-text">
-                <strong id="sessionName"></strong>
-                <span id="sessionRoles"></span>
-              </div>
-              <button id="logoutBtn" class="btn ghost small" type="button">Logout</button>
-            </div>
-          </div>
-          <img src="./assets/Sphere%20Logo_RGB%20_White.png" alt="Sphere" class="app-logo" />
-          <div class="topbar-title">
-            <span id="viewBadge" class="view-badge">Lead workspace</span>
-            <div class="title-stack">
-              <h1 class="app-title">Flight Log Form</h1>
-              <span class="title-sub">Tracking <span id="appTitle">Drone</span> activity</span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="container" role="main">
-    <section id="landingView" class="panel landing-panel view-landing-only" aria-labelledby="landingTitle">
-      <h2 id="landingTitle">Choose workspace</h2>
-      <p class="lead">Select the role you need for this session.</p>
-      <div class="role-options">
-        <div class="role-options-main">
-          <button id="chooseLead" type="button" class="btn primary role-btn">Lead</button>
-          <button id="chooseOperator" type="button" class="btn primary role-btn">Operator</button>
-        </div>
-        <div class="role-options-archive">
-          <button id="chooseArchive" type="button" class="btn primary role-btn">Archive</button>
-        </div>
-      </div>
-      <p class="help">Lead sets up shows and manages exports. Operator logs entries against those shows.</p>
     </section>
 
     <section id="archiveView" class="panel view-archive-only" aria-labelledby="archiveTitle">

--- a/public/styles.css
+++ b/public/styles.css
@@ -78,20 +78,24 @@ a{color:var(--primary);text-decoration:none}
 #roleHome{display:none}
 body.view-lead #roleHome,
 body.view-operator #roleHome,
-body.view-archive #roleHome{display:inline-flex}
+body.view-archive #roleHome,
+body.view-admin #roleHome{display:inline-flex}
 #viewBadge{display:none}
 body.view-lead #viewBadge,
 body.view-operator #viewBadge,
-body.view-archive #viewBadge{display:inline-flex}
+body.view-archive #viewBadge,
+body.view-admin #viewBadge{display:inline-flex}
 body.view-landing #refreshShows{display:none}
 .view-lead-only,
 .view-operator-only,
 .view-landing-only,
-.view-archive-only{display:none !important}
+.view-archive-only,
+.view-admin-only{display:none !important}
 body.view-lead .view-lead-only{display:block !important}
 body.view-operator .view-operator-only{display:block !important}
 body.view-landing .view-landing-only{display:block !important}
 body.view-archive .view-archive-only{display:block !important}
+body.view-admin .view-admin-only{display:block !important}
 #landingView{display:none;text-align:center;padding:38px 20px}
 body.view-landing #landingView{display:block}
 .role-options{


### PR DESCRIPTION
## Summary
- prevent the SPA from crashing during init by providing a no-op closeAdminPinPrompt helper
- move the admin tools out of the hamburger drawer into a dedicated admin workspace, wire the drawer up as a lightweight nav, and allow admins to reach the new view via the menu
- update view handling/UI state so admins can always navigate between workspaces, and so non-admins can still open the hamburger menu

## Testing
- npm test
- Manual: started the server, logged in as an admin, created a new admin account, and confirmed the new admin can reset their password and reach the landing and admin views

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69162fb2e19083238caa4137b635c672)