### PR TITLE
Add session-aware menu and operator entry restrictions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,14 +45,24 @@
       <div class="toolbar config-header">
         <h2 id="configTitle">Workspace menu</h2>
       </div>
-      <nav class="config-nav" aria-label="Workspace shortcuts">
-        <button type="button" class="config-nav-btn" data-config-target="landing">Choose workspace</button>
-        <button type="button" class="config-nav-btn" data-config-target="admin" id="adminWorkspaceNav">Admin workspace</button>
-      </nav>
-      <p class="help">Use the shortcuts above to jump between views. Admin access is required to open the admin workspace.</p>
+      <div class="config-session-card">
+        <div class="config-session-user">
+          <strong id="menuUserName">Not signed in</strong>
+          <span id="menuUserEmail"></span>
+          <span id="menuUserRoles" class="help"></span>
+        </div>
+        <div class="config-session-time">
+          <span class="help">Current time</span>
+          <strong id="menuDateTime"></strong>
+        </div>
+      </div>
+      <p class="help">Use the menu controls to confirm your session and jump into the admin workspace when authorized.</p>
       <div class="config-actions row">
         <div class="grow"></div>
         <button type="button" id="cancelConfig" class="btn ghost">Close menu</button>
+      </div>
+      <div class="config-footer">
+        <button type="button" class="config-nav-btn" data-config-target="admin" id="adminWorkspaceNav">Admin workspace</button>
       </div>
     </aside>
 
@@ -79,6 +89,7 @@
           </div>
           <img src="./assets/Sphere%20Logo_RGB%20_White.png" alt="Sphere" class="app-logo" />
           <div class="topbar-title">
+            <div id="welcomeBanner" class="welcome-banner" hidden></div>
             <span id="viewBadge" class="view-badge">Lead workspace</span>
             <div class="title-stack">
               <h1 class="app-title">Flight Log Form</h1>
@@ -114,35 +125,28 @@
       <form id="configForm" class="config-form">
         <section class="config-section grid is-active" data-config-section="admin">
           <div class="col-12 admin-users-panel">
-            <h3 id="userAccountsTitle">User accounts</h3>
-            <p class="help">Admins manage the roster here. Workspace lists automatically sync to assigned roles.</p>
-            <div id="userDirectory" class="user-directory" aria-live="polite"></div>
-            <div id="userForm" class="user-form" role="form" aria-labelledby="userAccountsTitle">
-              <input type="hidden" id="userId" />
-              <div class="grid">
-                <div class="col-6">
-                  <label for="userName">Name</label>
-                  <input id="userName" type="text" required />
-                </div>
-                <div class="col-6">
-                  <label for="userEmail">Email</label>
-                  <input id="userEmail" type="email" required />
-                </div>
-                <fieldset class="col-12 role-checkboxes">
-                  <legend>Roles</legend>
-                  <label><input type="checkbox" value="lead" name="userRole" /> Lead</label>
-                  <label><input type="checkbox" value="operator" name="userRole" /> Operator</label>
-                  <label><input type="checkbox" value="stagecrew" name="userRole" /> Stagecrew</label>
-                  <label><input type="checkbox" value="admin" name="userRole" /> Admin</label>
-                </fieldset>
+            <div class="admin-users-header">
+              <div>
+                <h3 id="userAccountsTitle">User accounts</h3>
+                <p class="help">Admins manage the roster here. Workspace lists automatically sync to assigned roles.</p>
               </div>
-              <div class="row form-actions">
-                <button type="button" id="userFormCancel" class="btn ghost">Cancel</button>
-                <button type="button" id="userFormSubmit" class="btn primary">Save user</button>
+              <div class="admin-users-actions">
+                <button type="button" id="newUserBtn" class="btn ghost">Add user</button>
               </div>
-              <p class="help small">New accounts receive the temporary password <code>adminsphere1</code> and must update it on first login.</p>
-              <div id="userFormStatus" class="help" role="status"></div>
             </div>
+            <div class="user-directory-controls">
+              <label class="sr-only" for="userSearch">Search users</label>
+              <input type="search" id="userSearch" placeholder="Search name or email" />
+              <label class="sr-only" for="userRoleFilter">Filter by role</label>
+              <select id="userRoleFilter">
+                <option value="">All roles</option>
+                <option value="lead">Lead</option>
+                <option value="operator">Operator</option>
+                <option value="stagecrew">Stagecrew</option>
+                <option value="admin">Admin</option>
+              </select>
+            </div>
+            <div id="userDirectory" class="user-directory" aria-live="polite"></div>
           </div>
           <div class="col-12">
             <label for="unitLabelSelect">Unit label</label>
@@ -367,8 +371,9 @@
           <div class="actions-chips" id="actionsChips" role="group" aria-label="Actions taken"></div>
         </div>
         <div class="col-3">
-          <label for="operator">Operator</label>
-          <select id="operator"></select>
+          <label for="operatorDisplay">Operator</label>
+          <input id="operatorDisplay" type="text" class="operator-display" readonly tabindex="-1" aria-readonly="true" placeholder="Sign in to log entries" />
+          <input type="hidden" id="operator" />
           <div class="error" id="errOperator" hidden>Required</div>
         </div>
         <div class="col-3">
@@ -392,6 +397,9 @@
           <label for="entryNotes">Notes</label>
           <textarea id="entryNotes" placeholder="Short note"></textarea>
         </div>
+        <div class="col-12">
+          <p id="operatorEntryNotice" class="operator-entry-notice" hidden></p>
+        </div>
         <div class="col-12 entry-actions">
           <button id="addLine" class="btn primary">Add line</button>
         </div>
@@ -402,6 +410,41 @@
   </div>
   </div>
 </div>
+
+  <div id="userModal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="userModalTitle" aria-hidden="true">
+    <div class="modal user-modal">
+      <div class="toolbar modal-toolbar">
+        <h2 id="userModalTitle">User account</h2>
+        <button type="button" id="closeUserModal" class="btn icon-btn" title="Close user editor">✖️</button>
+      </div>
+      <form id="userForm" class="user-form" role="form" aria-labelledby="userModalTitle">
+        <input type="hidden" id="userId" />
+        <div class="grid">
+          <div class="col-6">
+            <label for="userName">Name</label>
+            <input id="userName" type="text" required />
+          </div>
+          <div class="col-6">
+            <label for="userEmail">Email</label>
+            <input id="userEmail" type="email" required />
+          </div>
+          <fieldset class="col-12 role-checkboxes">
+            <legend>Roles</legend>
+            <label><input type="checkbox" value="lead" name="userRole" /> Lead</label>
+            <label><input type="checkbox" value="operator" name="userRole" /> Operator</label>
+            <label><input type="checkbox" value="stagecrew" name="userRole" /> Stagecrew</label>
+            <label><input type="checkbox" value="admin" name="userRole" /> Admin</label>
+          </fieldset>
+        </div>
+        <div class="row form-actions">
+          <button type="button" id="userFormCancel" class="btn ghost">Cancel</button>
+          <button type="button" id="userFormSubmit" class="btn primary">Save user</button>
+        </div>
+        <p class="help small">New accounts receive the temporary password <code>adminsphere1</code> and must update it on first login.</p>
+        <div id="userFormStatus" class="help" role="status"></div>
+      </form>
+    </div>
+  </div>
 
   <div id="webhookModal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="webhookModalTitle" aria-hidden="true">
     <div class="modal">

--- a/public/styles.css
+++ b/public/styles.css
@@ -84,7 +84,8 @@ body.view-admin #roleHome{display:inline-flex}
 body.view-lead #viewBadge,
 body.view-operator #viewBadge,
 body.view-archive #viewBadge,
-body.view-admin #viewBadge{display:inline-flex}
+body.view-admin #viewBadge,
+body.view-landing #viewBadge{display:inline-flex}
 body.view-landing #refreshShows{display:none}
 .view-lead-only,
 .view-operator-only,
@@ -129,6 +130,14 @@ body.view-landing #landingView{display:block}
 .role-options-archive .role-btn{
   flex:1 1 220px;
   max-width:320px;
+}
+.welcome-banner{
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+  color:var(--text-dim);
+  font-weight:700;
+  margin-bottom:4px;
 }
 .view-badge{
   background:transparent;
@@ -216,6 +225,11 @@ body.view-operator .topbar-actions{
 .session-user strong{font-size:14px;}
 .session-user span{font-size:12px;color:var(--text-dim);}
 .session-user .btn{margin-left:auto;}
+#logoutBtn:hover{
+  color:var(--danger);
+  border-color:rgba(255,93,93,.6);
+  background:rgba(255,93,93,.12);
+}
 .topbar-title{
   grid-area:title;
   margin-left:auto;
@@ -267,28 +281,53 @@ body.view-operator .topbar-actions{
 }
 .row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
 .grow{flex:1}
-.badge{  
+.badge{
   background:var(--chip); color:var(--text-dim); padding:6px 10px; border-radius:999px; font-size:12px; border:1px solid var(--border)
 }
 .badge.warn{background:rgba(255,184,77,.18);color:#ffda9c;border-color:rgba(255,184,77,.6);}
+.admin-users-panel{
+  background:rgba(12,16,26,.85);
+  border:1px solid var(--border);
+  border-radius:20px;
+  padding:20px;
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+  box-shadow:var(--shadow);
+}
+.admin-users-header{display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap;}
+.admin-users-actions .btn{min-width:140px;}
+.user-directory-controls{
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+  align-items:center;
+}
+.user-directory-controls input,
+.user-directory-controls select{
+  flex:1 1 220px;
+  min-width:180px;
+  border-radius:12px;
+  border:1px solid var(--border);
+  background:var(--input);
+  color:var(--text);
+  padding:10px 12px;
+}
 .user-directory{
   display:flex;
   flex-direction:column;
   gap:12px;
-  padding:16px;
-  margin:16px 0;
-  border:1px dashed rgba(255,255,255,.2);
-  border-radius:14px;
-  background:rgba(11,18,30,.65);
-  max-height:260px;
+  margin:0;
+  max-height:420px;
   overflow:auto;
+  padding-right:6px;
 }
 .user-form{
   padding:18px;
   border:1px solid rgba(255,255,255,.18);
   border-radius:16px;
-  background:rgba(8,15,25,.75);
-  box-shadow:0 16px 32px rgba(0,0,0,.35);
+  background:rgba(8,15,25,.9);
+  box-shadow:0 16px 32px rgba(0,0,0,.45);
 }
 .user-row{
   display:flex;
@@ -979,6 +1018,7 @@ summary::-webkit-details-marker{display:none}
   position:fixed; inset:0; background:rgba(0,0,0,.55); display:none; align-items:center; justify-content:center; z-index:80; padding:16px
 }
 .modal{background:var(--panel); border:1px solid var(--border); border-radius:var(--radius-lg); width:min(820px, 100%); max-height:90vh; overflow:auto; padding:16px}
+.user-modal{width:min(620px, 100%);}
 .modal-backdrop.open{display:flex}
 
 .toast{
@@ -1047,6 +1087,26 @@ summary::-webkit-details-marker{display:none}
   flex-direction:column;
   gap:12px;
 }
+.config-session-card{
+  border:1px solid var(--border);
+  border-radius:16px;
+  padding:16px;
+  background:rgba(255,255,255,.03);
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+.config-session-user strong{font-size:16px;}
+.config-session-user span{display:block;font-size:13px;}
+.config-session-time{
+  border-top:1px solid var(--border);
+  padding-top:8px;
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+}
+.config-footer{margin-top:auto;}
+.config-footer .config-nav-btn{width:100%;}
 .config.open{
   opacity:1;
   transform:translateX(0);
@@ -1120,6 +1180,26 @@ summary::-webkit-details-marker{display:none}
   border:1px solid var(--border); border-radius:999px; padding:8px 12px; background:var(--chip); cursor:pointer; user-select:none
 }
 .action-chip[aria-pressed="true"]{outline:3px solid rgba(154,209,255,.25); border-color:var(--focus)}
+.operator-display{
+  width:100%;
+  border-radius:12px;
+  border:1px solid var(--border);
+  background:rgba(255,255,255,.04);
+  color:var(--text);
+  padding:10px 12px;
+  font-weight:600;
+  cursor:not-allowed;
+  user-select:none;
+}
+.operator-entry-notice{
+  margin:0;
+  padding:10px 12px;
+  border-radius:12px;
+  border:1px dashed var(--border);
+  background:rgba(255,255,255,.03);
+  color:var(--text-dim);
+  font-size:13px;
+}
 .kbd{font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; background:#0d0f14; border:1px solid var(--border); padding:2px 6px; border-radius:6px; color:var(--text-dim)}
 .sr-only{position:absolute;left:-10000px;top:auto;width:1px;height:1px;overflow:hidden}
 


### PR DESCRIPTION
## Summary
- add a personalized welcome banner and expand the workspace drawer with session details, live clock, and footer admin navigation
- redesign the admin workspace to focus on the user directory, including modal-based editing plus search and role filtering controls
- restrict operator entry logging to the signed-in user, prevent duplicate entries per show, and enforce the identity server-side alongside the new idle/logout behaviours

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691635d7b9bc8323b0428099da4f8e16)