### PR TITLE
Add calendar view and discipline filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "axios": "^1.12.2",
         "express": "^5.1.0",
+        "https-proxy-agent": "^7.0.6",
         "morgan": "^1.10.1",
+        "node-ical": "^0.22.1",
         "pg": "^8.13.1",
         "sql.js": "^1.13.0",
         "uuid": "^13.0.0"
@@ -28,6 +30,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/asynckit": {
@@ -554,6 +565,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -694,6 +718,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-ical": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.22.1.tgz",
+      "integrity": "sha512-rMdc5hhJT3ZPtZIWfEXcetRrPl2xeHGpMJX8lq4VwyLKfOzGr+rXVtx0lD8lSf27Hn3mxrbU3MUcMSMXp4rIQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rrule": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/object-inspect": {
@@ -975,6 +1011,15 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1148,6 +1193,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "dependencies": {
     "axios": "^1.12.2",
     "express": "^5.1.0",
+    "https-proxy-agent": "^7.0.6",
     "morgan": "^1.10.1",
+    "node-ical": "^0.22.1",
     "pg": "^8.13.1",
     "sql.js": "^1.13.0",
     "uuid": "^13.0.0"

--- a/public/index.html
+++ b/public/index.html
@@ -108,6 +108,10 @@
       <h2 id="disciplineTitle">Choose discipline</h2>
       <p class="lead">Select the production discipline you want to manage.</p>
       <div id="disciplineList" class="discipline-options" role="list"></div>
+      <div class="discipline-actions" role="group" aria-label="Quick access">
+        <button id="chooseCalendar" type="button" class="btn ghost discipline-action-btn">View calendar</button>
+        <button id="chooseArchive" type="button" class="btn ghost discipline-action-btn">Open archive</button>
+      </div>
     </section>
 
     <section id="workspaceView" class="panel landing-panel view-workspace-only" aria-labelledby="workspaceTitle">
@@ -124,11 +128,34 @@
           <button id="chooseLead" type="button" class="btn primary role-btn">Lead</button>
           <button id="chooseOperator" type="button" class="btn primary role-btn">Operator</button>
         </div>
-        <div class="role-options-archive">
-          <button id="chooseArchive" type="button" class="btn primary role-btn">Archive</button>
-        </div>
       </div>
       <p class="help">Lead sets up shows and manages exports. Operator logs entries against those shows.</p>
+    </section>
+
+    <section id="calendarView" class="panel view-calendar-only" aria-labelledby="calendarTitle">
+      <div class="panel-header">
+        <h2 id="calendarTitle">Production calendar</h2>
+        <div class="panel-actions calendar-panel-actions">
+          <span id="calendarUpdatedAt" class="help"></span>
+          <button id="refreshCalendar" type="button" class="btn ghost">Refresh calendar</button>
+        </div>
+      </div>
+      <div class="calendar-controls" role="group" aria-label="Calendar filters">
+        <div class="control-group control-group-inline">
+          <label for="calendarDisciplineFilter">Discipline</label>
+          <select id="calendarDisciplineFilter">
+            <option value="">All disciplines</option>
+          </select>
+        </div>
+        <div class="control-group control-group-inline">
+          <label for="calendarSearch">Search</label>
+          <input id="calendarSearch" type="search" placeholder="Search events" />
+        </div>
+      </div>
+      <div id="calendarContent" class="calendar-content">
+        <div id="calendarEmpty" class="help">Calendar events will appear after syncing the feed.</div>
+        <div id="calendarEventList" class="calendar-event-list"></div>
+      </div>
     </section>
 
     <section id="adminView" class="panel view-admin-only" aria-labelledby="adminTitle">
@@ -245,12 +272,18 @@
           <div id="archiveModeControls" class="control-group"></div>
         </div>
         <div class="archive-chart-wrap">
-          <div class="archive-chart-panel">
-            <div class="archive-chart-filter control-group control-group-inline">
-              <label for="archiveOperatorFilter">Operator</label>
-              <select id="archiveOperatorFilter">
-                <option value="">All operators</option>
-              </select>
+        <div class="archive-chart-panel">
+          <div class="archive-chart-filter control-group control-group-inline">
+            <label for="archiveDisciplineFilter">Discipline</label>
+            <select id="archiveDisciplineFilter">
+              <option value="">All disciplines</option>
+            </select>
+          </div>
+          <div class="archive-chart-filter control-group control-group-inline">
+            <label for="archiveOperatorFilter">Operator</label>
+            <select id="archiveOperatorFilter">
+              <option value="">All operators</option>
+            </select>
             </div>
             <canvas id="archiveStatCanvas" class="archive-chart" role="img" aria-label="Archived show statistic over time"></canvas>
           </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -79,7 +79,8 @@ a{color:var(--primary);text-decoration:none}
 body.view-lead #roleHome,
 body.view-operator #roleHome,
 body.view-archive #roleHome,
-body.view-admin #roleHome{display:inline-flex}
+body.view-admin #roleHome,
+body.view-calendar #roleHome{display:inline-flex}
 #viewBadge{display:none}
 body.view-lead #viewBadge,
 body.view-operator #viewBadge,
@@ -87,7 +88,8 @@ body.view-archive #viewBadge,
 body.view-admin #viewBadge,
 body.view-landing #viewBadge,
 body.view-discipline #viewBadge,
-body.view-workspace #viewBadge{display:inline-flex}
+body.view-workspace #viewBadge,
+body.view-calendar #viewBadge{display:inline-flex}
 body.view-landing #refreshShows{display:none}
 .view-lead-only,
 .view-operator-only,
@@ -95,7 +97,8 @@ body.view-landing #refreshShows{display:none}
 .view-archive-only,
 .view-admin-only,
 .view-discipline-only,
-.view-workspace-only{display:none !important}
+.view-workspace-only,
+.view-calendar-only{display:none !important}
 body.view-lead .view-lead-only{display:block !important}
 body.view-operator .view-operator-only{display:block !important}
 body.view-landing .view-landing-only{display:block !important}
@@ -103,6 +106,7 @@ body.view-archive .view-archive-only{display:block !important}
 body.view-admin .view-admin-only{display:block !important}
 body.view-discipline .view-discipline-only{display:block !important}
 body.view-workspace .view-workspace-only{display:block !important}
+body.view-calendar .view-calendar-only{display:block !important}
 #landingView{display:none;text-align:center;padding:38px 20px}
 body.view-landing #landingView{display:block}
 .discipline-options,
@@ -126,8 +130,7 @@ body.view-landing #landingView{display:block}
   flex-wrap:wrap;
   width:min(100%, 640px);
 }
-.role-options-main,
-.role-options-archive{
+.role-options-main{
   display:flex;
   gap:16px;
   justify-content:center;
@@ -136,12 +139,15 @@ body.view-landing #landingView{display:block}
 .role-options-main .role-btn{
   flex:1 1 180px;
 }
-.role-options-archive{
-  padding-top:4px;
+.discipline-actions{
+  display:flex;
+  gap:16px;
+  flex-wrap:wrap;
+  justify-content:center;
+  margin:24px auto 0;
 }
-.role-options-archive .role-btn{
-  flex:1 1 220px;
-  max-width:320px;
+.discipline-action-btn{
+  min-width:180px;
 }
 .user-role-grid{
   display:grid;
@@ -1292,3 +1298,84 @@ summary::-webkit-details-marker{display:none}
   overflow:auto
 }
 .webhook-json code{color:inherit}
+.calendar-panel-actions{
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+  align-items:center;
+}
+.calendar-controls{
+  display:flex;
+  flex-wrap:wrap;
+  gap:16px;
+  margin:24px 0;
+}
+.calendar-content{
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+}
+.calendar-event-list{
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+}
+#calendarEmpty{margin:24px 0;}
+.calendar-day{
+  background:var(--panel);
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:16px;
+  padding:20px;
+  box-shadow:0 18px 36px rgba(0,0,0,.32);
+}
+.calendar-day-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  margin-bottom:16px;
+}
+.calendar-day-header h3{margin:0;font-size:18px;color:var(--text);}
+.calendar-day-count{font-size:14px;color:var(--text-dim);}
+.calendar-day-events{display:flex;flex-direction:column;gap:12px;}
+.calendar-event{
+  background:rgba(15,17,21,.92);
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:12px;
+  padding:16px;
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+.calendar-event-header{
+  display:flex;
+  justify-content:space-between;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.calendar-event-title{margin:0;font-size:16px;color:var(--text);}
+.calendar-event-meta{
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  font-size:14px;
+  color:var(--text-dim);
+}
+.calendar-event-description{
+  margin:0;
+  font-size:14px;
+  color:var(--text);
+  white-space:pre-wrap;
+}
+.calendar-event-links{
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  font-size:14px;
+}
+.calendar-event-links a{color:var(--primary);text-decoration:none;}
+.calendar-event-links a:hover{text-decoration:underline;}
+@media (max-width:720px){
+  .calendar-controls{flex-direction:column;align-items:stretch;}
+  .calendar-panel-actions{justify-content:flex-start;}
+}

--- a/server/calendarFeed.js
+++ b/server/calendarFeed.js
@@ -1,0 +1,195 @@
+const axios = require('axios');
+const ical = require('node-ical');
+const { HttpsProxyAgent } = require('https-proxy-agent');
+
+const { DISCIPLINES } = require('./disciplineConfig');
+
+const CALENDAR_FEED_URL = process.env.CALENDAR_FEED_URL
+  || process.env.TEAMUP_CALENDAR_URL
+  || 'https://ics.teamup.com/feed/8orye2s63sbb3virutab5ny6beycko/12007214.ics';
+
+const PROXY_URL = process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy || null;
+
+const DISCIPLINE_NAME_MAP = buildDisciplineLookup();
+
+function buildDisciplineLookup(){
+  const map = new Map();
+  DISCIPLINES.forEach(discipline => {
+    const id = String(discipline.id || '').trim().toLowerCase();
+    const name = String(discipline.name || '').trim().toLowerCase();
+    if(id){
+      map.set(id, id);
+    }
+    if(name){
+      map.set(name, id || name);
+    }
+  });
+  return map;
+}
+
+function createHttpConfig(){
+  const config = {
+    responseType: 'text',
+    timeout: 15000,
+    maxRedirects: 5
+  };
+  if(PROXY_URL){
+    const agent = new HttpsProxyAgent(PROXY_URL);
+    config.httpAgent = agent;
+    config.httpsAgent = agent;
+    config.proxy = false;
+  }
+  return config;
+}
+
+function normalizeString(value){
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function toTimestamp(value){
+  if(value instanceof Date){
+    const time = value.getTime();
+    return Number.isFinite(time) ? time : null;
+  }
+  if(typeof value === 'number' && Number.isFinite(value)){
+    return value;
+  }
+  if(typeof value === 'string' && value){
+    const parsed = Date.parse(value);
+    if(Number.isFinite(parsed)){
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function resolveDisciplineId(event){
+  if(!event){
+    return null;
+  }
+  const categories = Array.isArray(event.categories)
+    ? event.categories
+    : typeof event.categories === 'string'
+      ? event.categories.split(',')
+      : [];
+  for(const rawCategory of categories){
+    const category = normalizeString(rawCategory).toLowerCase();
+    if(!category){
+      continue;
+    }
+    if(DISCIPLINE_NAME_MAP.has(category)){
+      return DISCIPLINE_NAME_MAP.get(category) || null;
+    }
+  }
+  const summary = normalizeString(event.summary).toLowerCase();
+  if(summary){
+    for(const [key, value] of DISCIPLINE_NAME_MAP.entries()){
+      if(!key || !value){
+        continue;
+      }
+      if(summary.includes(key)){
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+function normalizeAttachments(raw){
+  if(!raw){
+    return [];
+  }
+  const list = Array.isArray(raw) ? raw : [raw];
+  const attachments = [];
+  list.forEach(item => {
+    if(!item){
+      return;
+    }
+    if(typeof item === 'string'){
+      const url = item.trim();
+      if(url){
+        attachments.push({url});
+      }
+      return;
+    }
+    if(typeof item === 'object'){
+      const url = normalizeString(item.val || item.url || '');
+      if(url){
+        attachments.push({
+          url,
+          mimeType: normalizeString(item.params?.FMTTYPE || item.params?.['FMTTYPE']),
+          label: normalizeString(item.params?.LABEL || item.params?.['X-LABEL'] || '')
+        });
+      }
+    }
+  });
+  return attachments;
+}
+
+function normalizeCalendarEvent(raw){
+  if(!raw || typeof raw !== 'object'){
+    return null;
+  }
+  const uid = normalizeString(raw.uid || raw.id);
+  if(!uid){
+    return null;
+  }
+  const startTs = toTimestamp(raw.start);
+  const endTs = toTimestamp(raw.end);
+  const description = normalizeString(raw.description || raw.summary || '');
+  const urlValue = typeof raw.url === 'string' ? raw.url : raw.url?.val;
+  const allDay = Boolean(raw.start?.dateOnly || raw.datetype === 'date' || String(raw['MICROSOFT-CDO-ALLDAYEVENT']).toUpperCase() === 'TRUE');
+  const createdAt = toTimestamp(raw.created);
+  const updatedAt = toTimestamp(raw.lastmodified || raw.dtstamp);
+  const disciplineId = resolveDisciplineId(raw);
+  return {
+    id: uid,
+    uid,
+    title: normalizeString(raw.summary) || 'Untitled event',
+    description,
+    location: normalizeString(raw.location || ''),
+    url: normalizeString(urlValue || ''),
+    start: Number.isFinite(startTs) ? new Date(startTs).toISOString() : null,
+    end: Number.isFinite(endTs) ? new Date(endTs).toISOString() : null,
+    startTs: Number.isFinite(startTs) ? startTs : null,
+    endTs: Number.isFinite(endTs) ? endTs : null,
+    allDay,
+    disciplineId,
+    category: normalizeString(Array.isArray(raw.categories) && raw.categories.length ? raw.categories[0] : ''),
+    who: normalizeString(raw['TEAMUP-WHO'] || raw.who || ''),
+    attachments: normalizeAttachments(raw.attach),
+    createdAt,
+    updatedAt
+  };
+}
+
+async function fetchCalendarEvents(options = {}){
+  const url = normalizeString(options.url || '') || CALENDAR_FEED_URL;
+  if(!url){
+    throw new Error('Calendar feed URL not configured');
+  }
+  const httpConfig = createHttpConfig();
+  const response = await axios.get(url, httpConfig);
+  const parsed = await ical.async.parseICS(response.data);
+  const events = [];
+  Object.values(parsed || {}).forEach(value => {
+    if(!value || value.type !== 'VEVENT'){
+      return;
+    }
+    const event = normalizeCalendarEvent(value);
+    if(event){
+      events.push(event);
+    }
+  });
+  events.sort((a, b) => {
+    const aTime = Number.isFinite(a.startTs) ? a.startTs : Number.isFinite(a.endTs) ? a.endTs : Infinity;
+    const bTime = Number.isFinite(b.startTs) ? b.startTs : Number.isFinite(b.endTs) ? b.endTs : Infinity;
+    return aTime - bTime;
+  });
+  return events;
+}
+
+module.exports = {
+  CALENDAR_FEED_URL,
+  fetchCalendarEvents
+};


### PR DESCRIPTION
## Summary
- add calendar feed ingestion with storage and API endpoints so events can be synced and filtered by discipline
- expose a production calendar view and landing shortcuts while wiring archive filters for discipline-aware metrics
- style the calendar layout and include new dependencies for ICS parsing and proxy-aware fetching

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69179da8d3f48324892b7910aadb37d4)